### PR TITLE
updated random number functions

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -192,11 +192,11 @@ void Cell::update_motility_vector( double dt_ )
 		return; 
 	}
 	
-	if( uniform_random() < dt_ / phenotype.motility.persistence_time || phenotype.motility.persistence_time < dt_ )
+	if( UniformRandom() < dt_ / phenotype.motility.persistence_time || phenotype.motility.persistence_time < dt_ )
 	{
 		// choose a uniformly random unit vector 
-		double temp_angle = 6.28318530717959*uniform_random();
-		double temp_phi = 3.1415926535897932384626433832795*uniform_random();
+		double temp_angle = 6.28318530717959*UniformRandom();
+		double temp_phi = 3.1415926535897932384626433832795*UniformRandom();
 		
 		double sin_phi = sin(temp_phi);
 		double cos_phi = cos(temp_phi);

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -65,6 +65,7 @@
 
 #include "../BioFVM/BioFVM.h"
 #include "./PhysiCell_constants.h"
+#include "./PhysiCell_utilities.h"
 
 using namespace BioFVM; 
 
@@ -305,7 +306,7 @@ void Cycle_Model::advance_model( Cell* pCell, Phenotype& phenotype, double dt )
 			else
 			{
 				double prob = phenotype.cycle.data.transition_rates[i][k]*dt; 
-				if( uniform_random() <= prob )
+				if( UniformRandom() <= prob )
 				{
 					continue_transition = true; 
 				}
@@ -440,7 +441,7 @@ bool Death::check_for_death( double dt )
 	int i = 0; 
 	while( !dead && i < rates.size() )
 	{
-		if( uniform_random() < rates[i]*dt )
+		if( UniformRandom() < rates[i]*dt )
 		{
 			// update the Death data structure 
 			dead = true; 


### PR DESCRIPTION
I changed the random uniform number generator function to use the one provided in PhysiCell_utilities to be consistent with the SeedRandom() function. Otherwise cells with random lifetimes on a single thread use the BioFVM version without specifying a seed, resulting in the same trajectory each time. 