### PR TITLE
Update user_guide.tex

### DIFF
--- a/documentation/User_Guide.tex
+++ b/documentation/User_Guide.tex
@@ -4010,8 +4010,10 @@ Note that Booleans can be represented as 0 and 1, or \v|false| and \v|true|.
 
 \subsection{Passing XML options to PhysiCell}
 \label{sec:XML_options}
-PhysiCell 1.3.0 introduced prelimanary support for XML configuration files, via 
-\v|./modules/PhysiCell_settings.*|. It primarily works by creating two data 
+PhysiCell 1.3.0 introduced preliminary support for XML configuration files, via 
+##This does not show up well on the pdf \v|./modules/PhysiCell_settings.*|. ##
+
+It primarily works by creating two data 
 structures defined as: 
 
 \begin{verbatim}


### PR DESCRIPTION
corrected spelling of preliminary from prelimanary and pointed out a place (DID NOT CORRECT) that a link does not show up correctly on pdf.