### PR TITLE
2 bugfixes for out-of-bounds cells, and code cleanup

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -462,14 +462,6 @@ void Cell::set_previous_velocity(double xV, double yV, double zV)
 
 bool Cell::assign_position(double x, double y, double z)
 {
-	if( !get_container()->underlying_mesh.is_position_valid(x,y,z) )
-	{	
-		is_out_of_domain = true; 
-		is_active = false; 
-		is_movable = false; 
-		
-		return false;
-	}
 	position[0]=x;
 	position[1]=y;
 	position[2]=z;
@@ -480,6 +472,15 @@ bool Cell::assign_position(double x, double y, double z)
 	current_mechanics_voxel_index= get_container()->underlying_mesh.nearest_voxel_index( position );
 	get_container()->register_agent(this);
 	
+	if( !get_container()->underlying_mesh.is_position_valid(x,y,z) )
+	{
+		is_out_of_domain = true;
+		is_active = false;
+		is_movable = false;
+
+		return false;
+	}
+
 	return true;
 }
 

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -425,6 +425,14 @@ Cell* Cell::divide( )
 	// position[0] -= 0.5*radius*rand_vec[0];
 	// position[1] -= 0.5*radius*rand_vec[1]; 
 	// position[2] -= 0.5*radius*rand_vec[2]; 
+
+	//If this cell has been moved outside of the boundaries, mark it as such.
+	//(If the child cell is outside of the boundaries, that has been taken care of in the assign_position function.)
+	if( !get_container()->underlying_mesh.is_position_valid(position[0], position[1], position[2])){
+		is_out_of_domain = true;
+		is_active = false;
+		is_movable = false;
+	}
 	 
 	update_voxel_in_container();
 	phenotype.volume.divide(); 

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -170,10 +170,10 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		#pragma omp parallel for 
 		for( int i=0; i < (*all_cells).size(); i++ )
 		{
-			if((*all_cells)[i]->is_out_of_domain)
-			{ continue; }
-			// (*all_cells)[i]->phenotype.advance_bundled_models( (*all_cells)[i] , time_since_last_cycle ); 
-			(*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle ); 
+			if(!(*all_cells)[i]->is_out_of_domain)
+			{
+				(*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle ); 
+			}
 		}
 		
 		// process divides / removes 
@@ -273,10 +273,10 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		#pragma omp parallel for 
 		for( int i=0; i < (*all_cells).size(); i++ )
 		{
-			if((*all_cells)[i]->is_out_of_domain)
-			{ continue; }
-			// (*all_cells)[i]->phenotype.advance_bundled_models( (*all_cells)[i] , time_since_last_cycle ); 
-			(*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle ); 
+			if(!(*all_cells)[i]->is_out_of_domain)
+			{
+				(*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle );
+			}
 		}
 		
 		// process divides / removes 

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -586,7 +586,8 @@ void standard_update_cell_velocity( Cell* pCell, Phenotype& phenotype, double dt
 		neighbor_voxel_index != neighbor_voxel_index_end; 
 		++neighbor_voxel_index )
 	{
-		if(is_neighbor_voxel(pCell, pCell->get_container()->underlying_mesh.voxels[pCell->get_current_mechanics_voxel_index()].center, pCell->get_container()->underlying_mesh.voxels[*neighbor_voxel_index].center, *neighbor_voxel_index)){
+		if(is_neighbor_voxel(pCell, pCell->get_container()->underlying_mesh.voxels[pCell->get_current_mechanics_voxel_index()].center, pCell->get_container()->underlying_mesh.voxels[*neighbor_voxel_index].center, *neighbor_voxel_index))
+		{
 			end = pCell->get_container()->agent_grid[*neighbor_voxel_index].end();
 			for(neighbor = pCell->get_container()->agent_grid[*neighbor_voxel_index].begin();neighbor != end; ++neighbor)
 			{

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -586,12 +586,12 @@ void standard_update_cell_velocity( Cell* pCell, Phenotype& phenotype, double dt
 		neighbor_voxel_index != neighbor_voxel_index_end; 
 		++neighbor_voxel_index )
 	{
-		if(!is_neighbor_voxel(pCell, pCell->get_container()->underlying_mesh.voxels[pCell->get_current_mechanics_voxel_index()].center, pCell->get_container()->underlying_mesh.voxels[*neighbor_voxel_index].center, *neighbor_voxel_index))
-			continue;
-		end = pCell->get_container()->agent_grid[*neighbor_voxel_index].end();
-		for(neighbor = pCell->get_container()->agent_grid[*neighbor_voxel_index].begin();neighbor != end; ++neighbor)
-		{
-			pCell->add_potentials(*neighbor);
+		if(is_neighbor_voxel(pCell, pCell->get_container()->underlying_mesh.voxels[pCell->get_current_mechanics_voxel_index()].center, pCell->get_container()->underlying_mesh.voxels[*neighbor_voxel_index].center, *neighbor_voxel_index)){
+			end = pCell->get_container()->agent_grid[*neighbor_voxel_index].end();
+			for(neighbor = pCell->get_container()->agent_grid[*neighbor_voxel_index].begin();neighbor != end; ++neighbor)
+			{
+				pCell->add_potentials(*neighbor);
+			}
 		}
 	}
 


### PR DESCRIPTION
- Cells that move outside of the boundaries in the process of dividing are now marked as out of bounds, avoiding a potential program crash.
- The assign_position function now assigns the position before checking whether the position is valid.  This corrects the 'center cell' bug, in which a new cell created in the divide function remains at (0,0,0) because the intended position is out of bounds.
- Eliminated unnecessary uses of 'continue'