### PR TITLE
fix location of default microenv

### DIFF
--- a/documentation/User_Guide.tex
+++ b/documentation/User_Guide.tex
@@ -5718,7 +5718,7 @@ std::string PhysiCell_URL;
 \label{sec:default_microenvironment}
 The name of the default microenvironment in PhysiCell is 
 \v|microenvironment|, which is declared in 
-\v|./core/PhysiCell_phenotype.cpp|. This strcture is initialized 
+\v|./BioFVM/BioFVM_microenvironment.cpp|. This structure is initialized 
 with the function 
 
 \v|initialize_microenvironment()|


### PR DESCRIPTION
`16.2 Default microenvironment` - `microenvironment` is not in `core/PhysiCell_phenotype.cpp`; it's in `BioFVM/BioFVM_microenvironment.cpp`.

Wasn't sure if you wanted PRs on all intermediate Latex files and .pdf, but thought a cleaner workflow might be to just PR edits to the .tex and then build the pdf just before dev --> master.