### PR TITLE
Checking if cell is out of domain before advancing secretion

### DIFF
--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -248,7 +248,10 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 	#pragma omp parallel for 
 	for( int i=0; i < (*all_cells).size(); i++ )
 	{
-		(*all_cells)[i]->phenotype.secretion.advance( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
+		if( (*all_cells)[i]->is_out_of_domain == false )
+		{
+			(*all_cells)[i]->phenotype.secretion.advance( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
+		}
 	}
 	
 	//if it is the time for running cell cycle, do it!


### PR DESCRIPTION
Without this check, cells outside of the domain would still produce secretions. 

Since cells outside of the domain have current_voxel_index = -1, this would mean using a negative index to get the voxel for the mesh's voxels vector. 
This would lead to unexpected behaviour, mostly garbage values, and on my system a segfault (still not sure why).