### PR TITLE
Interface to use custom Cell classes

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -129,7 +129,7 @@ Cell_Definition::Cell_Definition()
 		// the default Custom_Cell_Data constructor should take care of this
 		
 	// set up the default functions 
-	functions.instantiate_cell = standard_instantiate_cell;
+	functions.instantiate_cell = NULL;
 	functions.volume_update_function = NULL; // standard_volume_update_function;
 	functions.update_migration_bias = NULL; 
 	

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -84,6 +84,11 @@ std::vector<Cell_Definition*> cell_definitions_by_index;
 // in case you want the legacy method 
 std::vector<double> (*cell_division_orientation)(void) = UniformOnUnitSphere; // LegacyRandomOnUnitSphere; 
 
+Cell* standard_instantiate_cell()
+{ return new Cell; }
+
+Cell* (*instantiate_cell)() = standard_instantiate_cell;
+
 Cell_Parameters::Cell_Parameters()
 {
 	o2_hypoxic_threshold = 15.0; // HIF-1alpha at half-max around 1.5-2%, and tumors often are below 2%
@@ -871,7 +876,8 @@ void Cell::add_potentials(Cell* other_agent)
 Cell* create_cell( void )
 {
 	Cell* pNew; 
-	pNew = new Cell;		
+	pNew = instantiate_cell();
+	
 	(*all_cells).push_back( pNew ); 
 	pNew->index=(*all_cells).size()-1;
 	

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -875,7 +875,12 @@ void Cell::add_potentials(Cell* other_agent)
 Cell* create_cell( Cell* (*custom_instantiate)())
 {
 	Cell* pNew; 
-	pNew = custom_instantiate();
+	
+	if (custom_instantiate) {
+		pNew = custom_instantiate();
+	} else {
+		pNew = standard_instantiate_cell();
+	}
 	
 	(*all_cells).push_back( pNew ); 
 	pNew->index=(*all_cells).size()-1;

--- a/core/PhysiCell_cell.h
+++ b/core/PhysiCell_cell.h
@@ -226,7 +226,7 @@ class Cell : public Basic_Agent
 
 Cell* create_cell( void );  
 Cell* create_cell( Cell_Definition& cd );  
-
+extern Cell* (*instantiate_cell)();
 
 void delete_cell( int ); 
 void delete_cell( Cell* ); 

--- a/core/PhysiCell_cell.h
+++ b/core/PhysiCell_cell.h
@@ -224,7 +224,7 @@ class Cell : public Basic_Agent
 	void convert_to_cell_definition( Cell_Definition& cd ); 
 };
 
-Cell* create_cell( Cell* (*custom_instantiate)() );  
+Cell* create_cell( Cell* (*custom_instantiate)() = NULL );  
 Cell* create_cell( Cell_Definition& cd );  
 
 void delete_cell( int ); 

--- a/core/PhysiCell_cell.h
+++ b/core/PhysiCell_cell.h
@@ -224,9 +224,8 @@ class Cell : public Basic_Agent
 	void convert_to_cell_definition( Cell_Definition& cd ); 
 };
 
-Cell* create_cell( void );  
+Cell* create_cell( Cell* (*custom_instantiate)() );  
 Cell* create_cell( Cell_Definition& cd );  
-extern Cell* (*instantiate_cell)();
 
 void delete_cell( int ); 
 void delete_cell( Cell* ); 

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -1018,6 +1018,8 @@ void Molecular::advance( Basic_Agent* pCell, Phenotype& phenotype , double dt )
 
 Cell_Functions::Cell_Functions()
 {
+	instantiate_cell = NULL;
+	
 	volume_update_function = NULL; 
 	update_migration_bias = NULL; 
 	

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -433,6 +433,8 @@ class Cell_Functions
 {
  private:
  public:
+	Cell* (*instantiate_cell)(); 
+
 	Cycle_Model cycle_model; 
 
 	void (*volume_update_function)( Cell* pCell, Phenotype& phenotype , double dt ); // used in cell 


### PR DESCRIPTION
This PR adds an way to use custom cell classes, which are extensions of the Cell class.

We can cast from cell to custom cell back and forth in our custom functions, but the object needs to be instantiated using the custom cell constructor. 
To do this, we add a new custom function in Cell_Functions, to perform the instantiation : 
` 	Cell* (*instantiate_cell)(); `

We also add a standard_instantiate_cell, defined as such : 
```
Cell* standard_instantiate_cell()
{ return new Cell; }
```
When the pointer is null, this standard_instantiate_cell() function is called.