### PR TITLE
Initializing at zero num death and divisions in current step in container

### DIFF
--- a/core/PhysiCell_cell_container.h
+++ b/core/PhysiCell_cell_container.h
@@ -89,8 +89,8 @@ class Cell_Container : public BioFVM::Agent_Container
  public:
 	BioFVM::Cartesian_Mesh underlying_mesh;
 	std::vector<double> max_cell_interactive_distance_in_voxel;
-	int num_divisions_in_current_step;
-	int num_deaths_in_current_step;
+	int num_divisions_in_current_step = 0;
+	int num_deaths_in_current_step = 0;
 
 	double last_diffusion_time  = 0.0; 
 	double last_cell_cycle_time = 0.0;


### PR DESCRIPTION
In the cell container, num_divisions_in_current_step and num_deaths_in_current_step are not initialized.
When activating legacy data output, this will print uninitialized values for the first time point (in log_output function).
