### PR TITLE
OMP Performance Improvements and thread safety in diffusion calculation

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -972,147 +972,147 @@ void Microenvironment::compute_all_gradient_vectors( void )
 		two_dz *= 2.0;
 		gradient_constants_defined = true; 
 	}
-	
-	#pragma omp parallel for 
-	for( unsigned int k=0; k < mesh.z_coordinates.size() ; k++ )
+	#pragma omp parallel firstprivate(two_dx, two_dy, two_dz, gradient_constants_defined, thomas_i_jump, thomas_j_jump, thomas_k_jump)
 	{
-		for( unsigned int j=0; j < mesh.y_coordinates.size() ; j++ )
+		#pragma omp for
+		for( unsigned int k=0; k < mesh.z_coordinates.size() ; k++ )
 		{
-			// endcaps 
-			for( unsigned int q=0; q < number_of_densities() ; q++ )
+			for( unsigned int j=0; j < mesh.y_coordinates.size() ; j++ )
 			{
-				int i = 0; 
-				int n = voxel_index(i,j,k);
-				// x-derivative of qth substrate at voxel n
-				gradient_vectors[n][q][0] = (*p_density_vectors)[n+thomas_i_jump][q]; 
-				gradient_vectors[n][q][0] -= (*p_density_vectors)[n][q]; 
-				gradient_vectors[n][q][0] /= mesh.dx; 
-				
-				gradient_vector_computed[n] = true; 
-			}
-			for( unsigned int q=0; q < number_of_densities() ; q++ )
-			{
-				int i = mesh.x_coordinates.size()-1; 
-				int n = voxel_index(i,j,k);
-				// x-derivative of qth substrate at voxel n
-				gradient_vectors[n][q][0] = (*p_density_vectors)[n][q]; 
-				gradient_vectors[n][q][0] -= (*p_density_vectors)[n-thomas_i_jump][q]; 
-				gradient_vectors[n][q][0] /= mesh.dx; 
-				
-				gradient_vector_computed[n] = true; 
-			}
-			
-			for( unsigned int i=1; i < mesh.x_coordinates.size()-1 ; i++ )
-			{
+				// endcaps
 				for( unsigned int q=0; q < number_of_densities() ; q++ )
 				{
+					int i = 0;
 					int n = voxel_index(i,j,k);
 					// x-derivative of qth substrate at voxel n
 					gradient_vectors[n][q][0] = (*p_density_vectors)[n+thomas_i_jump][q]; 
+					gradient_vectors[n][q][0] -= (*p_density_vectors)[n][q];
+					gradient_vectors[n][q][0] /= mesh.dx;
+
+					gradient_vector_computed[n] = true;
+				}
+				for( unsigned int q=0; q < number_of_densities() ; q++ )
+				{
+					int i = mesh.x_coordinates.size()-1;
+					int n = voxel_index(i,j,k);
+					// x-derivative of qth substrate at voxel n
+					gradient_vectors[n][q][0] = (*p_density_vectors)[n][q];
 					gradient_vectors[n][q][0] -= (*p_density_vectors)[n-thomas_i_jump][q]; 
-					gradient_vectors[n][q][0] /= two_dx; 
+					gradient_vectors[n][q][0] /= mesh.dx;
 					
 					gradient_vector_computed[n] = true; 
- 				}
+				}
+
+				for( unsigned int i=1; i < mesh.x_coordinates.size()-1 ; i++ )
+				{
+					for( unsigned int q=0; q < number_of_densities() ; q++ )
+					{
+						int n = voxel_index(i,j,k);
+						// x-derivative of qth substrate at voxel n
+						gradient_vectors[n][q][0] = (*p_density_vectors)[n+thomas_i_jump][q];
+						gradient_vectors[n][q][0] -= (*p_density_vectors)[n-thomas_i_jump][q];
+						gradient_vectors[n][q][0] /= two_dx;
+
+						gradient_vector_computed[n] = true;
+					}
+				}
+
 			}
-			
 		}
-	}
-	
-	#pragma omp parallel for 
-	for( unsigned int k=0; k < mesh.z_coordinates.size() ; k++ )
-	{
-		for( unsigned int i=0; i < mesh.x_coordinates.size() ; i++ )
+
+		#pragma omp for
+		for( unsigned int k=0; k < mesh.z_coordinates.size() ; k++ )
 		{
-			// endcaps 
-			for( unsigned int q=0; q < number_of_densities() ; q++ )
+			for( unsigned int i=0; i < mesh.x_coordinates.size() ; i++ )
 			{
-				int j = 0; 
-				int n = voxel_index(i,j,k);
-				// x-derivative of qth substrate at voxel n
-				gradient_vectors[n][q][1] = (*p_density_vectors)[n+thomas_j_jump][q]; 
-				gradient_vectors[n][q][1] -= (*p_density_vectors)[n][q]; 
-				gradient_vectors[n][q][1] /= mesh.dy; 
-				
-				gradient_vector_computed[n] = true; 
-			}
-			for( unsigned int q=0; q < number_of_densities() ; q++ )
-			{
-				int j = mesh.y_coordinates.size()-1; 
-				int n = voxel_index(i,j,k);
-				// x-derivative of qth substrate at voxel n
-				gradient_vectors[n][q][1] = (*p_density_vectors)[n][q]; 
-				gradient_vectors[n][q][1] -= (*p_density_vectors)[n-thomas_j_jump][q]; 
-				gradient_vectors[n][q][1] /= mesh.dy; 
-				
-				gradient_vector_computed[n] = true; 
-			}		
-			
-			for( unsigned int j=1; j < mesh.y_coordinates.size()-1 ; j++ )
-			{
+				// endcaps
 				for( unsigned int q=0; q < number_of_densities() ; q++ )
 				{
+					int j = 0;
 					int n = voxel_index(i,j,k);
-					// y-derivative of qth substrate at voxel n
+					// x-derivative of qth substrate at voxel n
 					gradient_vectors[n][q][1] = (*p_density_vectors)[n+thomas_j_jump][q]; 
-					gradient_vectors[n][q][1] -= (*p_density_vectors)[n-thomas_j_jump][q]; 
-					gradient_vectors[n][q][1] /= two_dy; 
-					gradient_vector_computed[n] = true; 
-				}
-			}
-			
-		}
-	}
-	
-	// don't bother computing z component if there is no z-directoin 
-	if( mesh.z_coordinates.size() == 1 )
-	{ return; }
+					gradient_vectors[n][q][1] -= (*p_density_vectors)[n][q];
+					gradient_vectors[n][q][1] /= mesh.dy;
 
-	#pragma omp parallel for 
-	for( unsigned int j=0; j < mesh.y_coordinates.size() ; j++ )
-	{
-		for( unsigned int i=0; i < mesh.x_coordinates.size() ; i++ )
-		{
-			// endcaps 
-			for( unsigned int q=0; q < number_of_densities() ; q++ )
-			{
-				int k = 0; 
-				int n = voxel_index(i,j,k);
-				// x-derivative of qth substrate at voxel n
-				gradient_vectors[n][q][2] = (*p_density_vectors)[n+thomas_k_jump][q]; 
-				gradient_vectors[n][q][2] -= (*p_density_vectors)[n][q]; 
-				gradient_vectors[n][q][2] /= mesh.dz; 
-				
-				gradient_vector_computed[n] = true; 
-			}
-			for( unsigned int q=0; q < number_of_densities() ; q++ )
-			{
-				int k = mesh.z_coordinates.size()-1; 
-				int n = voxel_index(i,j,k);
-				// x-derivative of qth substrate at voxel n
-				gradient_vectors[n][q][2] = (*p_density_vectors)[n][q]; 
-				gradient_vectors[n][q][2] -= (*p_density_vectors)[n-thomas_k_jump][q]; 
-				gradient_vectors[n][q][2] /= mesh.dz; 
-				
-				gradient_vector_computed[n] = true; 
-			}			
-			
-			for( unsigned int k=1; k < mesh.z_coordinates.size()-1 ; k++ )
-			{
+					gradient_vector_computed[n] = true;
+				}
 				for( unsigned int q=0; q < number_of_densities() ; q++ )
 				{
+					int j = mesh.y_coordinates.size()-1;
 					int n = voxel_index(i,j,k);
-					// y-derivative of qth substrate at voxel n
-					gradient_vectors[n][q][2] = (*p_density_vectors)[n+thomas_k_jump][q]; 
-					gradient_vectors[n][q][2] -= (*p_density_vectors)[n-thomas_k_jump][q]; 
-					gradient_vectors[n][q][2] /= two_dz; 
+					// x-derivative of qth substrate at voxel n
+					gradient_vectors[n][q][1] = (*p_density_vectors)[n][q];
+					gradient_vectors[n][q][1] -= (*p_density_vectors)[n-thomas_j_jump][q]; 
+					gradient_vectors[n][q][1] /= mesh.dy;
+
 					gradient_vector_computed[n] = true; 
 				}
+
+				for( unsigned int j=1; j < mesh.y_coordinates.size()-1 ; j++ )
+				{
+					for( unsigned int q=0; q < number_of_densities() ; q++ )
+					{
+						int n = voxel_index(i,j,k);
+						// y-derivative of qth substrate at voxel n
+						gradient_vectors[n][q][1] = (*p_density_vectors)[n+thomas_j_jump][q];
+						gradient_vectors[n][q][1] -= (*p_density_vectors)[n-thomas_j_jump][q];
+						gradient_vectors[n][q][1] /= two_dy;
+						gradient_vector_computed[n] = true;
+					}
+				}
 			}
-			
+		}
+
+		// don't bother computing z component if there is no z-directoin
+		if( mesh.z_coordinates.size() > 1 )
+		{
+			#pragma omp for
+			for( unsigned int j=0; j < mesh.y_coordinates.size() ; j++ )
+			{
+				for( unsigned int i=0; i < mesh.x_coordinates.size() ; i++ )
+				{
+					// endcaps
+					for( unsigned int q=0; q < number_of_densities() ; q++ )
+					{
+						int k = 0;
+						int n = voxel_index(i,j,k);
+						// x-derivative of qth substrate at voxel n
+						gradient_vectors[n][q][2] = (*p_density_vectors)[n+thomas_k_jump][q];
+						gradient_vectors[n][q][2] -= (*p_density_vectors)[n][q];
+						gradient_vectors[n][q][2] /= mesh.dz;
+
+						gradient_vector_computed[n] = true;
+					}
+					for( unsigned int q=0; q < number_of_densities() ; q++ )
+					{
+						int k = mesh.z_coordinates.size()-1;
+						int n = voxel_index(i,j,k);
+						// x-derivative of qth substrate at voxel n
+						gradient_vectors[n][q][2] = (*p_density_vectors)[n][q];
+						gradient_vectors[n][q][2] -= (*p_density_vectors)[n-thomas_k_jump][q];
+						gradient_vectors[n][q][2] /= mesh.dz;
+
+						gradient_vector_computed[n] = true;
+					}
+
+					for( unsigned int k=1; k < mesh.z_coordinates.size()-1 ; k++ )
+					{
+						for( unsigned int q=0; q < number_of_densities() ; q++ )
+						{
+							int n = voxel_index(i,j,k);
+							// y-derivative of qth substrate at voxel n
+							gradient_vectors[n][q][2] = (*p_density_vectors)[n+thomas_k_jump][q];
+							gradient_vectors[n][q][2] -= (*p_density_vectors)[n-thomas_k_jump][q];
+							gradient_vectors[n][q][2] /= two_dz;
+							gradient_vector_computed[n] = true;
+						}
+					}
+
+				}
+			}
 		}
 	}
-
 	return; 
 }
 

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -137,52 +137,53 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 	//if it is the time for running cell cycle, do it!
 	double time_since_last_cycle= t- last_cell_cycle_time;
 
-	static double phenotype_dt_tolerance = 0.001 * phenotype_dt_; 
-	static double mechanics_dt_tolerance = 0.001 * mechanics_dt_; 
-	
+	static double phenotype_dt_tolerance = 0.001 * phenotype_dt_;
+	static double mechanics_dt_tolerance = 0.001 * mechanics_dt_;
+		
 	if( fabs(time_since_last_cycle-phenotype_dt_ ) < phenotype_dt_tolerance || !initialzed)
 	{
 		// Reset the max_radius in each voxel. It will be filled in set_total_volume
-		// It might be better if we calculate it before mechanics each time 
+		// It might be better if we calculate it before mechanics each time
 		// std::fill(max_cell_interactive_distance_in_voxel.begin(), max_cell_interactive_distance_in_voxel.end(), 0.0);
-		
+
 		if(!initialzed)
 		{
 			time_since_last_cycle = phenotype_dt_;
 		}
-		
-		// new as of 1.2.1 -- bundles cell phenotype parameter update, volume update, geometry update, 
+
+		// new as of 1.2.1 -- bundles cell phenotype parameter update, volume update, geometry update,
 		// checking for death, and advancing the cell cycle. Not motility, though. (that's in mechanics)
-		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "bundled phenotype" << std::endl; 
-		#pragma omp parallel for 
+		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "bundled phenotype" << std::endl;
+
+		#pragma omp parallel for firstprivate(t, phenotype_dt_, mechanics_dt_, diffusion_dt_)
 		for( int i=0; i < (*all_cells).size(); i++ )
 		{
 			if( (*all_cells)[i]->is_out_of_domain == false )
 			{
-				(*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle ); 
+				(*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle );
 			}
 		}
-		
-		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "divide / die " << std::endl; 
-		// process divides / removes 
+
+		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "divide / die " << std::endl;
+		// process divides / removes
 		for( int i=0; i < cells_ready_to_divide.size(); i++ )
 		{
 			cells_ready_to_divide[i]->divide();
 		}
 		for( int i=0; i < cells_ready_to_die.size(); i++ )
-		{	
-			cells_ready_to_die[i]->die();	
+		{
+			cells_ready_to_die[i]->die();
 		}
 		num_divisions_in_current_step+=  cells_ready_to_divide.size();
 		num_deaths_in_current_step+=  cells_ready_to_die.size();
-		
+
 		cells_ready_to_die.clear();
 		cells_ready_to_divide.clear();
 		last_cell_cycle_time= t;
 	}
-		
+
 	double time_since_last_mechanics= t- last_mechanics_time;
-	
+
 	// if( time_since_last_mechanics>= mechanics_dt || !initialzed)
 	if( fabs(time_since_last_mechanics - mechanics_dt_) < mechanics_dt_tolerance || !initialzed)
 	{
@@ -190,66 +191,69 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		{
 			time_since_last_mechanics = mechanics_dt_;
 		}
-		
-		// new February 2018 
+
+		// new February 2018
 		// if we need gradients, compute them
-		if( default_microenvironment_options.calculate_gradients ) 
+		if( default_microenvironment_options.calculate_gradients )
 		{ microenvironment.compute_all_gradient_vectors();  }
-		// end of new in Feb 2018 
-		
-		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "interactions" << std::endl; 
-		// perform interactions -- new in June 2020 
-		#pragma omp parallel for 
-		for( int i=0; i < (*all_cells).size(); i++ )
-		{
-			Cell* pC = (*all_cells)[i]; 
-			if( pC->functions.contact_function && pC->is_out_of_domain == false )
-			{ evaluate_interactions( pC,pC->phenotype,time_since_last_mechanics ); }
-		}
-		
-		// perform custom computations 
+		// end of new in Feb 2018
 
-		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "custom" << std::endl; 
-		#pragma omp parallel for 
-		for( int i=0; i < (*all_cells).size(); i++ )
+		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "interactions" << std::endl;
+		// perform interactions -- new in June 2020
+		#pragma omp parallel firstprivate(t, phenotype_dt_, mechanics_dt_, diffusion_dt_)
 		{
-			Cell* pC = (*all_cells)[i]; 
-			if( pC->functions.custom_cell_rule && pC->is_out_of_domain == false )
-			{ pC->functions.custom_cell_rule( pC,pC->phenotype,time_since_last_mechanics ); }
-		}
-		
-		// update velocities 
-		
-		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "velocity" << std::endl; 
-		#pragma omp parallel for 
-		for( int i=0; i < (*all_cells).size(); i++ )
-		{
-			Cell* pC = (*all_cells)[i]; 
-			if( pC->functions.update_velocity && pC->is_out_of_domain == false && pC->is_movable )
-			{ pC->functions.update_velocity( pC,pC->phenotype,time_since_last_mechanics ); }
-		}
+			#pragma omp for
+			for( int i=0; i < (*all_cells).size(); i++ )
+			{
+				Cell* pC = (*all_cells)[i];
+				if( pC->functions.contact_function && pC->is_out_of_domain == false )
+				{ evaluate_interactions( pC,pC->phenotype,time_since_last_mechanics ); }
+			}
 
-		// update positions 
-		
-		// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "position" << std::endl; 
-		#pragma omp parallel for 
-		for( int i=0; i < (*all_cells).size(); i++ )
-		{
-			Cell* pC = (*all_cells)[i]; 
-			if( pC->is_out_of_domain == false && pC->is_movable)
-			{ pC->update_position(time_since_last_mechanics); }
+			// perform custom computations
+
+			// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "custom" << std::endl;
+			#pragma omp for
+			for( int i=0; i < (*all_cells).size(); i++ )
+			{
+				Cell* pC = (*all_cells)[i];
+				if( pC->functions.custom_cell_rule && pC->is_out_of_domain == false )
+				{ pC->functions.custom_cell_rule( pC,pC->phenotype,time_since_last_mechanics ); }
+			}
+
+			// update velocities
+
+			// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "velocity" << std::endl;
+			#pragma omp for
+			for( int i=0; i < (*all_cells).size(); i++ )
+			{
+				Cell* pC = (*all_cells)[i];
+				if( pC->functions.update_velocity && pC->is_out_of_domain == false && pC->is_movable )
+				{ pC->functions.update_velocity( pC,pC->phenotype,time_since_last_mechanics ); }
+			}
+
+			// update positions
+
+			// std::cout << __FILE__ << " " << __FUNCTION__ << " " << __LINE__ << " " << "position" << std::endl;
+			#pragma omp for
+			for( int i=0; i < (*all_cells).size(); i++ )
+			{
+				Cell* pC = (*all_cells)[i];
+				if( pC->is_out_of_domain == false && pC->is_movable)
+				{ pC->update_position(time_since_last_mechanics); }
+			}
 		}
-		
-/*		
+			
+/*
 		// Compute custom functions, interations, and velocities
-		#pragma omp parallel for 
+		#pragma omp parallel for
 		for( int i=0; i < (*all_cells).size(); i++ )
 		{
 
 			if(!(*all_cells)[i]->is_out_of_domain && (*all_cells)[i]->is_movable && (*all_cells)[i]->functions.update_velocity )
 			{
-				// update_velocity already includes the motility update 
-				//(*all_cells)[i]->phenotype.motility.update_motility_vector( (*all_cells)[i] ,(*all_cells)[i]->phenotype , time_since_last_mechanics ); 
+				// update_velocity already includes the motility update
+				//(*all_cells)[i]->phenotype.motility.update_motility_vector( (*all_cells)[i] ,(*all_cells)[i]->phenotype , time_since_last_mechanics );
 				(*all_cells)[i]->functions.update_velocity( (*all_cells)[i], (*all_cells)[i]->phenotype, time_since_last_mechanics);
 			}
 
@@ -257,17 +261,17 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 			{
 				(*all_cells)[i]->functions.custom_cell_rule((*all_cells)[i], (*all_cells)[i]->phenotype, time_since_last_mechanics);
 			}
-			
-			// contact interactions 
-			
+
+			// contact interactions
+
 			if( (*all_cells)[i]->functions.contact_function )
 			{
 				evaluate_interactions( (*all_cells)[i] , (*all_cells)[i]->phenotype, time_since_last_mechanics );
 			}
-			
+
 		}
 		// Calculate new positions
-		#pragma omp parallel for 
+		#pragma omp parallel for
 		for( int i=0; i < (*all_cells).size(); i++ )
 		{
 			if(!(*all_cells)[i]->is_out_of_domain && (*all_cells)[i]->is_movable)
@@ -275,14 +279,18 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 				(*all_cells)[i]->update_position(time_since_last_mechanics);
 			}
 		}
-*/		
-		
-		// When somebody reviews this code, let's add proper braces for clarity!!! 
-		
+*/
+
+		// When somebody reviews this code, let's add proper braces for clarity!!!
+
 		// Update cell indices in the container
 		for( int i=0; i < (*all_cells).size(); i++ )
+		{
 			if(!(*all_cells)[i]->is_out_of_domain && (*all_cells)[i]->is_movable)
+			{
 				(*all_cells)[i]->update_voxel_in_container();
+			}
+		}
 		last_mechanics_time=t;
 	}
 	


### PR DESCRIPTION
View Changes with `git diff -w` for better readability.
(https://github.com/MathCancer/PhysiCell/pull/81/commits/7e08089198de5d3fcc8c0c88f826b10658047b3e?&w=1)
(https://github.com/MathCancer/PhysiCell/pull/81/commits/2b93b60475432daf775af6f524390ea26514562d?&w=1)

Commit 7e08089198de5d3fcc8c0c88f826b10658047b3e tries to minimize thread creation/destruction during BioFVM microenvironment gradient and diffusion calculation method. See also https://www.openmp.org/resources/refguides/.

Commit 2b93b60475432daf775af6f524390ea26514562d utilizes the variables temporary_density_vectors_1 as specified in
BioFVM_microenvironment.h:70
```cpp
/*! For internal use and accelerations in solvers */ 
	std::vector< std::vector<double> > temporary_density_vectors1; 
	/*! For internal use and accelerations in solvers */ 
	std::vector< std::vector<double> > temporary_density_vectors2; 
```
to accelerate calculation of diffusion results and obtain thread safe results in Thomas algorithm.
Lastly mentioned changes originated from a Slack Discussion https://physicellcomm-sf93727.slack.com/archives/C022762KLGN/p1643999577850329.