### PR TITLE
Fix/intracellular memory leak

### DIFF
--- a/addons/dFBA/src/dfba_intracellular.cpp
+++ b/addons/dFBA/src/dfba_intracellular.cpp
@@ -18,7 +18,10 @@ dFBAIntracellular::dFBAIntracellular(dFBAIntracellular* copy)
     intracellular_type = copy->intracellular_type;
 	sbml_filename = copy->sbml_filename;
 	parameters = copy->parameters;
-    model = copy->model;
+    // model = copy->model;
+    model.readSBMLModel(copy->sbml_filename.c_str());
+    model.initLpModel();
+    model.runFBA();
 }
 
 

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -589,7 +589,8 @@ class Intracellular
 	virtual std::string get_state() = 0;  
 	
 	virtual Intracellular* clone() = 0;
-    
+	
+	virtual ~Intracellular(){};
 	
 
     // ================  specific to "maboss" ================


### PR DESCRIPTION
This commit adds a virtual destructor to the Intracellular class, allowing both this destructor and the destructor of the derived class to be called at object destruction. 

It comes with another commit, fixing the copy constructor of the dFBAIntracellular and preventing a double free.