### PR TITLE
Updating PhysiBoSS to 2.1.0

### DIFF
--- a/.github/workflows/test-macosx.yml
+++ b/.github/workflows/test-macosx.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
     
 jobs:
-  build:
+  build_virus_macrophage:
 
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2
@@ -23,13 +23,23 @@ jobs:
     - name: Run Virus Macrophage cell lines project
       run: |
         ./virus-sample
-        
+
+
+  build_physiboss_cell_lines:
+
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run : brew install gcc@11
+      
     - name: Build PhysiBoSS cell lines project
       run: |
-        make reset
         make physiboss-cell-lines-sample
         make clean
-        make PHYSICELL_CPP=g++-10
+        make PHYSICELL_CPP=g++-11
         
     - name: Run PhysiBoSS cell lines project
       run: |

--- a/addons/PhysiBoSS/src/maboss_intracellular.cpp
+++ b/addons/PhysiBoSS/src/maboss_intracellular.cpp
@@ -23,6 +23,7 @@ MaBoSSIntracellular::MaBoSSIntracellular(MaBoSSIntracellular* copy)
 	discrete_time = copy->discrete_time;
 	time_tick = copy->time_tick;
 	scaling = copy->scaling;
+	time_stochasticity = copy->time_stochasticity;
 	initial_values = copy->initial_values;
 	mutations = copy->mutations;
 	parameters = copy->parameters;
@@ -35,6 +36,7 @@ MaBoSSIntracellular::MaBoSSIntracellular(MaBoSSIntracellular* copy)
 		maboss.set_update_time_step(copy->time_step);
 		maboss.set_discrete_time(copy->discrete_time, copy->time_tick);
 		maboss.set_scaling(copy->scaling);
+		maboss.set_time_stochasticity(copy->time_stochasticity);
 		maboss.restart_node_values();
 		//maboss.set_state(copy->maboss.get_maboss_state());
 		//std::cout << get_state();
@@ -123,6 +125,13 @@ void MaBoSSIntracellular::initialize_intracellular_from_pugixml(pugi::xml_node& 
 	{ 
 		scaling = PhysiCell::xml_get_my_double_value( node_scaling );
 		maboss.set_scaling(scaling);
+	}
+	
+	pugi::xml_node node_time_stochasticity = node.child( "time_stochasticity" );
+	if( node_time_stochasticity )
+	{
+		time_stochasticity = PhysiCell::xml_get_my_double_value( node_time_stochasticity );
+		maboss.set_time_stochasticity(time_stochasticity);
 	}
 }
 

--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -24,7 +24,8 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 	bool discrete_time = false;
 	double time_tick = 0.5;
 	double scaling = 1.0;
-	
+	double time_stochasticity = 0.0;
+
 	std::map<std::string, double> initial_values;
 	std::map<std::string, double> mutations;
 	std::map<std::string, double> parameters;

--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -9,7 +9,7 @@
 #include "../../../modules/PhysiCell_pugixml.h"
 #include "maboss_network.h"
 
-static std::string PhysiBoSS_Version = "2.0.0"; 
+static std::string PhysiBoSS_Version = "2.1.0"; 
 
 class MaBoSSIntracellular : public PhysiCell::Intracellular {
  private:

--- a/addons/PhysiBoSS/src/maboss_network.h
+++ b/addons/PhysiBoSS/src/maboss_network.h
@@ -35,7 +35,11 @@ class MaBoSSNetwork
 		/** \brief Real time to update, after applying noise */
 		double time_to_update;
 
+		/** \brief Scaling coefficient for time */
 		double scaling = 1.0;
+		
+		/** \brief Noise coefficient for time to update */
+		double time_stochasticity = 0;
 		
 		/** \brief Initial value probabilities, by node */
 		std::map< std::string, double > initial_values;
@@ -46,7 +50,7 @@ class MaBoSSNetwork
 		std::map< std::string, Node*> nodesByName;
 		std::map< std::string, const Symbol*> parametersByName;
 	
-		inline void set_time_to_update(){this->time_to_update = this->get_update_time_step();}
+		inline void set_time_to_update(){this->time_to_update = ( 1 + (PhysiCell::UniformRandom()*2-1)*time_stochasticity ) * this->get_update_time_step();}
 
 	
 	public:
@@ -129,6 +133,8 @@ class MaBoSSNetwork
 		}
 
 		inline void set_scaling(double scaling) { this->scaling = scaling; }
+		
+		inline void set_time_stochasticity(double t_stochasticity) { this->time_stochasticity = t_stochasticity; }
 		
 		/** 
 		 * \brief Print current state of all the nodes of the network 

--- a/beta/setup_libmaboss.py
+++ b/beta/setup_libmaboss.py
@@ -25,7 +25,7 @@ else:
 
     if os_type.lower() == 'darwin':
         mb_file = "libMaBoSS-osx64.tar.gz"
-    elif os_type.lower().startswith("win"):
+    elif os_type.lower().startswith("win") or os_type.lower().startswith("msys_nt") or os_type.lower().startswith("mingw64_nt"):
         mb_file = "libMaBoSS-win64.tar.gz"
     elif os_type.lower().startswith("linux"):
         mb_file = "libMaBoSS-linux64.tar.gz"

--- a/beta/setup_libmaboss.py
+++ b/beta/setup_libmaboss.py
@@ -83,6 +83,7 @@ else:
         tar = tarfile.open(mb_file)
         tar.extractall()
         tar.close()
+        os.remove(mb_file)
     except:
         print('error untarring the file')
         exit(1)

--- a/beta/setup_libmaboss.py
+++ b/beta/setup_libmaboss.py
@@ -33,7 +33,7 @@ else:
         print("Your operating system seems to be unsupported. Please submit a ticket at https://sourceforge.net/p/physicell/tickets/ ")
         sys.exit(1)
 
-    url = "http://maboss.curie.fr/pub/" + mb_file
+    url = "https://github.com/sysbio-curie/MaBoSS-env-2.0/releases/download/v2.4.1/" + mb_file
 
     fname = mb_file
 

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -205,7 +205,7 @@ reset:
 MaBoSS-clean:
 	rm -fr addons/PhysiBoSS/MaBoSS-env-2.0
 	
-clean: MaBoSS-clean
+clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*
 	

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -172,6 +172,9 @@ PhysiCell_settings.o: ./modules/PhysiCell_settings.cpp
 	
 # user-defined PhysiCell modules
 
+Compile_MaBoSS: MaBoSS
+	cd ./addons/PhysiBoSS/MaBoSS-env-2.0/engine/src;make install_alib;make clean; cd ../../../../..
+
 MaBoSS: 
 ifeq ($(OS), Windows_NT)
 	python beta/setup_libmaboss.py

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/config/PhysiCell_settings.xml
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/config/PhysiCell_settings.xml
@@ -147,9 +147,9 @@
 			<phenotype>
 				<cycle code="2" name="live">  
 					<!-- using higher than normal significant digits to match divisions in default code -->
-					<transition_rates units="1/min"> 
+					<phase_transition_rates units="1/min"> 
 						<rate start_index="0" end_index="0" fixed_duration="true">0.0</rate>
-					</transition_rates>
+					</phase_transition_rates>
 				</cycle>
 				
 				<death>  


### PR DESCRIPTION
First update of PhysiBoSS addon to v2.1.0 : 
- Restored stochastic update time, as Gaëlle was originally doing it. Disabled by default, but available via the XML settings.
- Improved error handling
- Updated PhysiBoSS cell lines example to work with latest version of PhysiCell
- Now using libMaBoSS v2.4.1, downloaded directly from the github release
- Improved cleanup of PhysiBoSS folder, not running it every time we do a make clean on the physiboss cell lines project.