### PR TITLE
Automatic mapping for PhysiBoSS

### DIFF
--- a/addons/PhysiBoSS/src/maboss_intracellular.cpp
+++ b/addons/PhysiBoSS/src/maboss_intracellular.cpp
@@ -333,8 +333,21 @@ void MaBoSSIntracellular::display(std::ostream& os)
 		os << "\t\t\t" << mutation.first << " = " << mutation.second << std::endl;
 
 	os 	<< "\t\t scaling = " << scaling << std::endl
-		<< "\t\t time_stochasticity = " << time_stochasticity << std::endl
-		<< std::endl;
+		<< "\t\t time_stochasticity = " << time_stochasticity << std::endl;
+
+	os	<< "\t\t " << listOfInputs.size() << " input mapping defined" << std::endl;
+	for (auto& input : listOfInputs)
+		os 	<< "\t\t\t" << input.physicell_name << " = " << input.intracellular_name
+			<< "(" << input.threshold << ", " << input.inact_threshold << ", " << input.smoothing << ")"
+			<< std::endl;
+
+	os	<< "\t\t " << listOfOutputs.size() << " output mapping defined" << std::endl;
+	for (auto& output : listOfOutputs)
+		os 	<< "\t\t\t" << output.physicell_name << " = " << output.intracellular_name 
+			<< "(" << output.value << ", " << output.base_value << ", " << output.smoothing << ")"
+			<< std::endl;
+	
+	std::cout << std::endl;
 }
 
 void MaBoSSIntracellular::save(std::string filename, std::vector<PhysiCell::Cell*>& cells)

--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -8,6 +8,7 @@
 #include "../../../core/PhysiCell_cell.h"
 #include "../../../modules/PhysiCell_pugixml.h"
 #include "maboss_network.h"
+#include "utils.h"
 
 static std::string PhysiBoSS_Version = "2.1.0"; 
 

--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -32,7 +32,9 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 	std::map<std::string, double> parameters;
 
 	std::vector<MaBoSSInput> listOfInputs;
+	std::vector<int> indicesOfInputs;
 	std::vector<MaBoSSOutput> listOfOutputs;
+	std::vector<int> indicesOfOutputs;
 	MaBoSSNetwork maboss;
 
 	double next_physiboss_run = 0;
@@ -62,7 +64,9 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 	}
 
 	void update(PhysiCell::Cell * cell, PhysiCell::Phenotype& phenotype, double dt) {
+		this->update_inputs(cell, phenotype, dt);
 		this->maboss.run_simulation();
+		this->update_outputs(cell, phenotype, dt);
 		this->next_physiboss_run += this->maboss.get_time_to_update();
 	}
 	
@@ -70,6 +74,9 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 		return PhysiCell::PhysiCell_globals.current_time >= this->next_physiboss_run;
 	}
 	
+	void update_inputs(PhysiCell::Cell* cell, PhysiCell::Phenotype& phenotype, double dt);
+	void update_outputs(PhysiCell::Cell * cell, PhysiCell::Phenotype& phenotype, double dt);
+
 	bool has_variable(std::string name) {
 		return this->maboss.has_node(name);
 	}

--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -30,7 +30,9 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 	std::map<std::string, double> initial_values;
 	std::map<std::string, double> mutations;
 	std::map<std::string, double> parameters;
-	
+
+	std::vector<MaBoSSInput> listOfInputs;
+	std::vector<MaBoSSOutput> listOfOutputs;
 	MaBoSSNetwork maboss;
 
 	double next_physiboss_run = 0;

--- a/addons/PhysiBoSS/src/maboss_network.h
+++ b/addons/PhysiBoSS/src/maboss_network.h
@@ -4,7 +4,6 @@
 #include "StochasticSimulationEngine.h"
 #include "BooleanNetwork.h"
 #include "RunConfig.h"
-#include "utils.h"
 #include "../../../core/PhysiCell_utilities.h"
 
 /**

--- a/addons/PhysiBoSS/src/utils.h
+++ b/addons/PhysiBoSS/src/utils.h
@@ -1,4 +1,51 @@
 #ifndef _PhysiBoSS_utils_h_
 #define _PhysiBoSS_utils_h_
+#include "maboss_network.h"
+class MaBoSSInput
+{
+    static const int NODE = 0;
+    static const int PARAMETER = 1;
 
+public:
+    std::string physicell_name;
+    int type;
+    std::string intracellular_name;
+    std::string intracellular_parameter;
+    std::string action;
+    double threshold;
+    double inact_threshold;
+    double scaling;
+    int smoothing;
+    double smoothed_value;
+    MaBoSSInput(std::string physicell_name, std::string intracellular_name, std::string action, double threshold, double inact_threshold, int smoothing) : physicell_name(physicell_name), intracellular_name(intracellular_name), action(action), threshold(threshold), inact_threshold(inact_threshold), smoothing(smoothing) {
+        type = NODE;
+        smoothed_value = 0;
+    }
+
+    MaBoSSInput(std::string physicell_name, std::string intracellular_parameter, double scaling, int smoothing) : physicell_name(physicell_name), intracellular_parameter(intracellular_parameter), scaling(scaling), smoothing(smoothing) {
+        type = PARAMETER;
+        smoothed_value = 0;
+    }
+
+    bool isNode() { return type == NODE; }
+    bool isParameter() { return type == PARAMETER; }
+
+};
+
+class MaBoSSOutput
+{
+public:
+    std::string physicell_name;
+    std::string intracellular_name;
+    std::string action;
+    double value;
+    double base_value;
+    int smoothing;
+    double smoothed_value;
+
+    MaBoSSOutput(std::string physicell_name, std::string intracellular_name, std::string action, double value, double base_value, int smoothing) : physicell_name(physicell_name), intracellular_name(intracellular_name), action(action), value(value), base_value(base_value), smoothing(smoothing) {
+        smoothed_value = base_value;
+    }
+
+};
 #endif

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/config/PhysiCell_settings.xml
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/config/PhysiCell_settings.xml
@@ -125,7 +125,7 @@
 				<decay_rate units="1/min">.1</decay_rate> 
 			</physical_parameter_set>
 			<initial_condition units="mmHg">38.0</initial_condition>
-			<Dirichlet_boundary_condition units="mmHg" enabled="true">38.0</Dirichlet_boundary_condition>
+			<Dirichlet_boundary_condition units="mmHg" enabled="false">38.0</Dirichlet_boundary_condition>
 		</variable>
 
 		<options>
@@ -179,11 +179,30 @@
 				<intracellular type="maboss">
 					<bnd_filename>./config/model_0.bnd</bnd_filename>
 					<cfg_filename>./config/model.cfg</cfg_filename>
-					<time_step>1</time_step>
+					<settings>
+						<intracellular_dt>1</intracellular_dt>
+					</settings>
 					<initial_values>
-						<initial_value node="A">1</initial_value>
-						<initial_value node="C">0</initial_value>
-					</initial_values>	
+						<initial_value intracellular_name="A">1</initial_value>
+						<initial_value intracellular_name="C">0</initial_value>
+					</initial_values>
+					<mapping>
+						<input physicell_name="oxygen" intracellular_name="A">
+							<settings>
+								<action>inhibition</action>
+								<threshold>10</threshold>
+								<inact_threshold>10</inact_threshold>
+							</settings>
+						</input>
+						<output physicell_name="apoptosis" intracellular_name="C">
+							<settings>
+								<action>activation</action>
+								<value>5</value>
+								<base_value>0</base_value>
+								<smoothing>5</smoothing>
+							</settings>
+						</output>
+					</mapping>
 				</intracellular>
 			</phenotype>
 			<custom_data/>
@@ -199,9 +218,11 @@
 		<cell_definition name="another" parent_type="default" ID="2">
 			<phenotype>
 				<intracellular type="maboss">
-					<mutations>
-						<mutation node="C">0.0</mutation>
-					</mutations>
+					<settings>
+						<mutations>
+							<mutation intracellular_name="C">0.0</mutation>
+						</mutations>
+					</settings>
 				</intracellular>			
 			</phenotype>
 			<custom_data/>
@@ -209,9 +230,11 @@
 		<cell_definition name="yet_another" parent_type="default" ID="3">
 			<phenotype>
 				<intracellular type="maboss">
-					<parameters>
-						<parameter name="$time_scale">0.2</parameter>
-					</parameters>
+					<settings>
+						<parameters>
+							<parameter intracellular_name="$time_scale">0.2</parameter>
+						</parameters>
+					</settings>
 				</intracellular>
 			</phenotype>
 			<custom_data/>
@@ -219,7 +242,9 @@
 		<cell_definition name="yet_yet_another" parent_type="default" ID="4">
 			<phenotype>
 				<intracellular type="maboss">
-					<scaling>0.25</scaling>
+					<settings>
+						<scaling>0.25</scaling>
+					</settings>
 				</intracellular>
 			</phenotype>
 			<custom_data/>
@@ -227,9 +252,11 @@
 		<cell_definition name="last_one" parent_type="default" ID="5">
 			<phenotype>
 				<intracellular type="maboss">
-					<parameters>
-						<parameter name="$time_scale">0.0</parameter>
-					</parameters>
+					<settings>
+						<parameters>
+							<parameter intracellular_name="$time_scale">0.0</parameter>
+						</parameters>
+					</settings>
 				</intracellular>
 			</phenotype>
 			<custom_data/>

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/config/model.cfg
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/config/model.cfg
@@ -1,4 +1,5 @@
 $time_scale = 0.05;
+$oxygen_concentration = 0.0;
 
 discrete_time = 0;
 use_physrandgen = FALSE;

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
@@ -115,9 +115,20 @@ void create_cell_types( void )
 	*/
 
 	build_cell_definitions_maps(); 
+
+	/*
+	   This intializes cell signal and response dictionaries 
+	*/
+
+	setup_signal_behavior_dictionaries();
+
+	/*
+	   This summarizes the setup. 
+	*/
 	
 	display_cell_definitions( std::cout ); 
-	
+
+
 	return; 
 }
 


### PR DESCRIPTION
This PR introduces automatic mapping for PhysiBoSS. Through the XML, users can link PhysiCell signals values to PhysiBoSS node states, and PhysiBoSS node states to PhysiCell behaviours.

Ex : 
```
<intracellular type="maboss">
	<bnd_filename>./config/model_0.bnd</bnd_filename>
	<cfg_filename>./config/model.cfg</cfg_filename>
	...
	<mapping>
		<input name="oxygen" node="A" action="inhibition" threshold="5" inact_threadshold="5" smoothing="0"/>
		<output name="apoptosis" node="C" action="activation" value="5" basal_value="0" smoothing="5"/>
	</mapping>
</intracellular>
```

In this example, available as a part of the PhysiBoSS cell lines example, the value of the input node A is active when oxygen is below 5 (oxygen is inversely proportional to A : it's an inhibition). A threshold for inactivating the node is also available, to allow for hysteresis. A smoothing can also be applied, to only activate the node when the condition has been true for several consecutive steps.
The other mapping links the activity of the node C to the apoptosis rate of the cells: when the node is active the rate is 5, otherwise it's 0 (the rate of apoptosis is proportional to C state : it's an activation). A smoothing is also applied, where the apoptosis level only reach 5 if smoothing is active for 5 consecutive steps.

This PR also introduce a change in the intracellular interface, with the introduction of a new update function : 

`	virtual void update(Cell* cell, Phenotype& phenotype, double dt) = 0;`

This allows to query and change the cell and phenotype state, as well as accessing the phenotype_dt (but maybe it should not be there, and it should be the intracellular_dt defined in the intracellular model). 

!!!!! This change will break other intracellular models, since it's a pure virtual method and other models have to implement it. !!!!!
But let's discuss it first :)
