### PR TITLE
Automatic intracellular update

### DIFF
--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -57,6 +57,11 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 		this->maboss.run_simulation();
 		this->next_physiboss_run += this->maboss.get_time_to_update();
 	}
+
+	void update(PhysiCell::Cell * cell, PhysiCell::Phenotype& phenotype, double dt) {
+		this->maboss.run_simulation();
+		this->next_physiboss_run += this->maboss.get_time_to_update();
+	}
 	
 	bool need_update() {
 		return PhysiCell::PhysiCell_globals.current_time >= this->next_physiboss_run;

--- a/addons/libRoadrunner/src/librr_intracellular.h
+++ b/addons/libRoadrunner/src/librr_intracellular.h
@@ -88,7 +88,10 @@ class RoadRunnerIntracellular : public PhysiCell::Intracellular
 
     // Need 'int' return type to avoid bizarre compile errors.
 	void update();
-    
+	void update(PhysiCell::Cell* cell, PhysiCell::Phenotype& phenotype, double dt) {
+		update();
+		update_phenotype_parameters(phenotype);
+	}
     
     int update_phenotype_parameters(PhysiCell::Phenotype& phenotype);
     int validate_PhysiCell_tokens(PhysiCell::Phenotype& phenotype);

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -146,7 +146,13 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 	{
 		if( (*all_cells)[i]->phenotype.intracellular != NULL  && (*all_cells)[i]->phenotype.intracellular->need_update())
 		{
+			if ((*all_cells)[i]->functions.pre_update_intracellular != NULL)
+				(*all_cells)[i]->functions.pre_update_intracellular( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
+
 			(*all_cells)[i]->phenotype.intracellular->update( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
+
+			if ((*all_cells)[i]->functions.post_update_intracellular != NULL)
+				(*all_cells)[i]->functions.post_update_intracellular( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
 		}
 	}
 	

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -139,6 +139,17 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 	static double phenotype_dt_tolerance = 0.001 * phenotype_dt_; 
 	static double mechanics_dt_tolerance = 0.001 * mechanics_dt_; 
 	
+	// intracellular update. called for every diffusion_dt, but actually depends on the intracellular_dt of each cell (as it can be noisy)
+
+	#pragma omp parallel for 
+	for( int i=0; i < (*all_cells).size(); i++ )
+	{
+		if( (*all_cells)[i]->phenotype.intracellular != NULL  && (*all_cells)[i]->phenotype.intracellular->need_update())
+		{
+			(*all_cells)[i]->phenotype.intracellular->update( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
+		}
+	}
+	
 	if( fabs(time_since_last_cycle-phenotype_dt_ ) < phenotype_dt_tolerance || !initialzed)
 	{
 		// Reset the max_radius in each voxel. It will be filled in set_total_volume

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -1149,6 +1149,9 @@ Cell_Functions::Cell_Functions()
 	update_phenotype = NULL; 
 	custom_cell_rule = NULL; 
 	
+	pre_update_intracellular = NULL;
+	post_update_intracellular = NULL;
+
 	update_velocity = NULL; 
 	add_cell_basement_membrane_interactions = NULL; 
 	calculate_distance_to_membrane = NULL; 

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -606,6 +606,7 @@ class Intracellular
 
 	// This function update the model for the time_step defined in the xml definition
 	virtual void update() = 0;
+	virtual void update(Cell* cell, Phenotype& phenotype, double dt) = 0;
 
 	// Get value for model parameter
 	virtual double get_parameter_value(std::string name) = 0;

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -482,6 +482,9 @@ class Cell_Functions
 	void (*custom_cell_rule)( Cell* pCell, Phenotype& phenotype, double dt ); 
 	void (*update_phenotype)( Cell* pCell, Phenotype& phenotype, double dt ); // used in celll
 	
+	void (*pre_update_intracellular) ( Cell* pCell, Phenotype& phenotype, double dt );
+	void (*post_update_intracellular) ( Cell* pCell, Phenotype& phenotype, double dt );
+
 	void (*update_velocity)( Cell* pCell, Phenotype& phenotype, double dt ); 
 	
 	void (*add_cell_basement_membrane_interactions)(Cell* pCell, Phenotype& phenotype, double dt );

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
@@ -183,23 +183,13 @@ void setup_tissue( void )
 
 void tumor_cell_phenotype_with_signaling( Cell* pCell, Phenotype& phenotype, double dt )
 {
+	if (PhysiCell::PhysiCell_globals.current_time >= 100.0 
+		&& pCell->phenotype.intracellular->get_parameter_value("$time_scale") == 0.0
+	){
+		pCell->phenotype.intracellular->set_parameter_value("$time_scale", 0.1);
+	}
 	
-	if (pCell->phenotype.intracellular->need_update())
-	{	
-		if (
-			pCell->type == get_cell_definition("last_one").type
-			&& PhysiCell::PhysiCell_globals.current_time >= 100.0 
-			&& pCell->phenotype.intracellular->get_parameter_value("$time_scale") == 0.0
-		)
-			pCell->phenotype.intracellular->set_parameter_value("$time_scale", 0.1);
-
-		set_input_nodes(pCell);
-
-		pCell->phenotype.intracellular->update();
-		
-		from_nodes_to_cell(pCell, phenotype, dt);
-		color_node(pCell);
-	}	
+	color_node(pCell);
 }
 
 

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
@@ -89,7 +89,8 @@ void create_cell_types( void )
 	cell_defaults.functions.update_velocity = NULL;
 
 	cell_defaults.functions.update_migration_bias = NULL; 
-	cell_defaults.functions.update_phenotype = tumor_cell_phenotype_with_signaling; // update_cell_and_death_parameters_O2_based; 
+	cell_defaults.functions.pre_update_intracellular = pre_update_intracellular; 
+	cell_defaults.functions.post_update_intracellular = post_update_intracellular; 
 	cell_defaults.functions.custom_cell_rule = NULL; 
 	
 	cell_defaults.functions.add_cell_basement_membrane_interactions = NULL; 
@@ -181,17 +182,19 @@ void setup_tissue( void )
 }
 
 
-void tumor_cell_phenotype_with_signaling( Cell* pCell, Phenotype& phenotype, double dt )
+void pre_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt )
 {
 	if (PhysiCell::PhysiCell_globals.current_time >= 100.0 
 		&& pCell->phenotype.intracellular->get_parameter_value("$time_scale") == 0.0
 	){
 		pCell->phenotype.intracellular->set_parameter_value("$time_scale", 0.1);
 	}
-	
-	color_node(pCell);
 }
 
+void post_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt )
+{
+	color_node(pCell);
+}
 
 void set_input_nodes(Cell* pCell) {}
 

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
@@ -181,7 +181,6 @@ void setup_tissue( void )
 	return; 
 }
 
-
 void pre_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt )
 {
 	if (PhysiCell::PhysiCell_globals.current_time >= 100.0 
@@ -195,11 +194,6 @@ void post_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt )
 {
 	color_node(pCell);
 }
-
-void set_input_nodes(Cell* pCell) {}
-
-void from_nodes_to_cell(Cell* pCell, Phenotype& phenotype, double dt) {}
-
 
 std::vector<std::string> my_coloring_function( Cell* pCell )
 {

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.h
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.h
@@ -86,9 +86,6 @@ std::vector<std::string> my_coloring_function( Cell* );
 // custom cell phenotype functions could go here 
 void pre_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt );
 void post_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt );
-/** \brief Write Density values to output file */
-void set_input_nodes(Cell* pCell); 
-void from_nodes_to_cell(Cell* pCell, Phenotype& phenotype, double dt);
 void color_node(Cell* pCell);
 
 #endif

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.h
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.h
@@ -84,7 +84,8 @@ void setup_microenvironment( void );
 std::vector<std::string> my_coloring_function( Cell* );
 
 // custom cell phenotype functions could go here 
-void tumor_cell_phenotype_with_signaling( Cell* pCell, Phenotype& phenotype, double dt );
+void pre_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt );
+void post_update_intracellular( Cell* pCell, Phenotype& phenotype, double dt );
 /** \brief Write Density values to output file */
 void set_input_nodes(Cell* pCell); 
 void from_nodes_to_cell(Cell* pCell, Phenotype& phenotype, double dt);


### PR DESCRIPTION
This pull request changes the way intracellular model updates. 
First, I'm adding a new format for the update function, which is the classic physicell format (Cell*, Phenotype&, double). This allows access to this data during our update function. 

Then, when and how to call it. Historically, PhysiBoSS used to do this in the update_phenotype function, because it could get away with it thanks to intracellular dt > phenotype_dt. Then with libRoadRunner and dFBA, a smaller dt was needed, so Furkan and Miguel implemented it as a call in the main.cpp, calling a function defined in the custom.cpp.
Here the function is now directly called in the update_all_cells, every diffusion_dt. More precisely, it is called if an intracellular model is defined, and if the time has come to update it (need_update()). 

One problem with this automation of the update, is that we loose the support for writing custom rules, not possible to write with our mappings. That's why I went a little overboard, and added two function pointers to Cell_Functions : one for pre, and one for post-treatment around the intracellular update. Let me know what you think about this one ;)

I updated PhysiBoSS, and wrote a tentative implementation for libRR (dFBA already had the same exact function so everything compiles). Still, the examples for libRR and dFBA are probably brocken since we have to rethink how update the model.

Let me know what you think !
