### PR TITLE
Update PhysiCell_cell.cpp

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -462,12 +462,7 @@ void Cell::assign_orientation()
 	else
 	{
 		//assign a random unit vector
-		double theta= UniformRandom()*6.28318530717959; //rand*2*pi
-		double z= 2* UniformRandom()-1;
-		double temp= sqrt(1-z*z);
-		state.orientation[0]= temp * cos(theta);
-		state.orientation[1]= temp * sin(theta);
-		state.orientation[2]= z;
+		state.orientation = UniformOnUnitSphere();
 	}
 	
 	return; 


### PR DESCRIPTION
Fixed random orientation vector selection by using the standardized UniformOnUnitSphere function. Before, the z-value was uniform on [-1,1] which is not the desired uniformity.