### PR TITLE
Added inheritance mechanism to intracellular class

### DIFF
--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -74,6 +74,8 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 		return PhysiCell::PhysiCell_globals.current_time >= this->next_physiboss_run;
 	}
 	
+	void inherit(PhysiCell::Cell * cell) {
+	}
 	void update_inputs(PhysiCell::Cell* cell, PhysiCell::Phenotype& phenotype, double dt);
 	void update_outputs(PhysiCell::Cell * cell, PhysiCell::Phenotype& phenotype, double dt);
 

--- a/addons/dFBA/src/dfba_intracellular.h
+++ b/addons/dFBA/src/dfba_intracellular.h
@@ -76,7 +76,8 @@ class dFBAIntracellular : public PhysiCell::Intracellular
 	void update(){ };
 
 	void update(PhysiCell::Cell* pCell, PhysiCell::Phenotype& phenotype, double dt);
-    
+    void inherit(PhysiCell::Cell * cell) {}
+	
 	int update_phenotype_parameters(PhysiCell::Phenotype& phenotype);
 	bool has_variable(std::string name) { return true; }
 

--- a/addons/libRoadrunner/src/librr_intracellular.h
+++ b/addons/libRoadrunner/src/librr_intracellular.h
@@ -93,6 +93,8 @@ class RoadRunnerIntracellular : public PhysiCell::Intracellular
 		update_phenotype_parameters(phenotype);
 	}
     
+	void inherit(PhysiCell::Cell * cell) {}
+	
     int update_phenotype_parameters(PhysiCell::Phenotype& phenotype);
     int validate_PhysiCell_tokens(PhysiCell::Phenotype& phenotype);
     int validate_SBML_species();

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -598,9 +598,10 @@ Cell* Cell::divide( )
 	// child->set_phenotype( phenotype ); 
 	child->phenotype = phenotype; 
 
-    if (child->phenotype.intracellular)
+    if (child->phenotype.intracellular){
         child->phenotype.intracellular->start();
-	
+		child->phenotype.intracellular->inherit(this);
+	}
 // #ifdef ADDON_PHYSIDFBA
 // 	child->fba_model = this->fba_model;
 // #endif

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -611,6 +611,9 @@ class Intracellular
 	virtual void update() = 0;
 	virtual void update(Cell* cell, Phenotype& phenotype, double dt) = 0;
 
+	// This function deals with inheritance from mother to daughter cells
+	virtual void inherit(Cell* cell) = 0;
+
 	// Get value for model parameter
 	virtual double get_parameter_value(std::string name) = 0;
 	


### PR DESCRIPTION
I started implementing a proper inheritance mechanism for PhysiBoSS, and I think it should become a part of the Intracellular class. The idea is to add a new method to the Intracellular interface : 

`void inherit(Cell* cell)`

This will be called during the divide() function, to inherit the state of the mother cell in the daughter cell. Each intracellular implementation would have to implement it. I have a very early version for PhysiBoSS that Marco will test in the next days, but I already wanted to submit this to have your opinions. 

