### PR TITLE
Allowing for derived Cell objects, defined by cell types

### DIFF
--- a/BioFVM/BioFVM_basic_agent.h
+++ b/BioFVM/BioFVM_basic_agent.h
@@ -111,7 +111,7 @@ class Basic_Agent
 	void update_position( double dt );
 	
 	Basic_Agent(); 
-
+	virtual ~Basic_Agent(){};
 	// simulate secretion and uptake at the nearest voxel at the indicated microenvironment.
 	// if no microenvironment indicated, use the currently selected microenvironment. 
 	void simulate_secretion_and_uptake( Microenvironment* M, double dt ); 

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -101,6 +101,9 @@ std::unordered_map<int,int> cell_definition_indices_by_type;
 // in case you want the legacy method 
 std::vector<double> (*cell_division_orientation)(void) = UniformOnUnitSphere; // LegacyRandomOnUnitSphere; 
 
+Cell* standard_instantiate_cell()
+{ return new Cell; }
+
 Cell_Parameters::Cell_Parameters()
 {
 	o2_hypoxic_threshold = 15.0; // HIF-1alpha at half-max around 1.5-2%, and tumors often are below 2%
@@ -148,6 +151,7 @@ Cell_Definition::Cell_Definition()
 		// the default Custom_Cell_Data constructor should take care of this
 		
 	// set up the default functions 
+	functions.instantiate_cell = NULL;
 	functions.volume_update_function = NULL; // standard_volume_update_function;
 	functions.update_migration_bias = NULL; 
 	
@@ -552,7 +556,7 @@ Cell* Cell::divide( )
 	}
 
 	
-	Cell* child = create_cell();
+	Cell* child = create_cell(functions.instantiate_cell);
 	child->copy_data( this );	
 	child->copy_function_pointers(this);
 	child->parameters = parameters;
@@ -1048,10 +1052,16 @@ void Cell::add_potentials(Cell* other_agent)
 	return;
 }
 
-Cell* create_cell( void )
+Cell* create_cell( Cell* (*custom_instantiate)())
 {
 	Cell* pNew; 
-	pNew = new Cell;		
+	
+	if (custom_instantiate) {
+		pNew = custom_instantiate();
+	} else {
+		pNew = standard_instantiate_cell();
+	}
+	
 	(*all_cells).push_back( pNew ); 
 	pNew->index=(*all_cells).size()-1;
 	
@@ -1074,7 +1084,7 @@ Cell* create_cell( void )
 // In that "create_cell()" uses "create_cell( cell_defaults )" 
 Cell* create_cell( Cell_Definition& cd )
 {
-	Cell* pNew = create_cell(); 
+	Cell* pNew = create_cell(cd.functions.instantiate_cell); 
 	
 	// use the cell defaults; 
 	pNew->type = cd.type; 

--- a/core/PhysiCell_cell.h
+++ b/core/PhysiCell_cell.h
@@ -200,7 +200,7 @@ class Cell : public Basic_Agent
 	void step(double dt);
 	Cell();
 	
-	~Cell(); 
+	virtual ~Cell(); 
 	
 	bool assign_position(std::vector<double> new_position);
 	bool assign_position(double, double, double);
@@ -251,7 +251,7 @@ class Cell : public Basic_Agent
 	void convert_to_cell_definition( Cell_Definition& cd ); 
 };
 
-Cell* create_cell( void );  
+Cell* create_cell( Cell* (*custom_instantiate)() = NULL );  
 Cell* create_cell( Cell_Definition& cd );  
 
 void delete_cell( int ); 

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -1141,6 +1141,8 @@ void Molecular::advance( Basic_Agent* pCell, Phenotype& phenotype , double dt )
 
 Cell_Functions::Cell_Functions()
 {
+	instantiate_cell = NULL;
+	
 	volume_update_function = NULL; 
 	update_migration_bias = NULL; 
 	

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -474,6 +474,8 @@ class Cell_Functions
 {
  private:
  public:
+	Cell* (*instantiate_cell)(); 
+
 	Cycle_Model cycle_model; 
 
 	void (*volume_update_function)( Cell* pCell, Phenotype& phenotype , double dt ); // used in cell 


### PR DESCRIPTION
I had proposed a PR some time ago already around this idea, but then I wasn't sure it was so important and it ended up being closed. 
With the new implementation of PhysiMESS, I wanted to revive it, as I think it will enable things which are not possible otherwise (mostly at destruction), and simplify our life a lot for designing extensions of the Cell class. 

The idea is that for PhysiMESS (and possibly other addons) we need to add new variables to the Cell. We can do this by having our own data structure, like :
```
std::map<Cell*, SomeObject> physimess_cell_object;
```
which is how I defined it for now. And it works, you have to initialize it after cell instantiation, and it's not so bad. But at deletion it's a problem, because we can never clean it at the exact same time as the Cell deletion. 
But with derived class, we would have our own constructor/destructors, so it would simplify instantiation and would allow proper destruction.
Also, important to note, it's a non-breaking change, everything would keep working the same way as before for those who don't want to use derived classes of Cell. 


The basic workflow would be the following : First, we defined our specialized class. Here I won't go into details, you get the idea.
```
class PhysiMESS_Cell : public Cell 
{ ... }
class PhysiMESS_Fibre : public Cell 
{ ... }
```

Then we need to be sure that at cell creation, we are instantiating the proper Class. To do this, we create new custom functions, and we assign them to a function pointer in the Cell_Functions class, depending on the cell type

``` 
Cell* instanciate_physimess_cell () { return new PhysiMeSS_Cell; }
Cell* instanciate_physimess_fibre () { return new PhysiMeSS_Fibre; }

create_cell_type() 
{
...
initialize_cell_definitions_from_pugixml(); 
...
// Default cell, in our case a PhysiMESS cell 
cell_defaults.functions.instantiate_cell = instantiate_physimess_cell;
...
// PhysiMeSS fibre
pCD = find_cell_definition( "fibre"); 
pCD->functions.instantiate_cell = instantiate_physimess_fibre;
...
}
```

Then, either in setup_tissue, or in load_cells_from_pugixml, when we would use 
```
create_cell(cell_definition);
```
it would automatically call the proper constructor via the instantiate_cell function pointer defined in the cell's definition Cell_Functions class. If this function pointer is NULL, then it will call a standard one. 
The way it works is that create_cell will now have an optional argument, which is a function pointer to an instantiate functions : 
```
Cell* standard_instantiate_cell() { return new Cell; }

Cell* create_cell( Cell* (*custom_instantiate)() = NULL );  
Cell* create_cell( Cell* (*custom_instantiate)())
{
	Cell* pNew; 

	if (custom_instantiate) {
		pNew = custom_instantiate();
	} else {
		pNew = standard_instantiate_cell();
	}
        ...
}
```
So the old create_cell() will still work and create a default_cell, but if we want a custom function we can put it as argument.
And create_cell(Cell_Definition) can now use it : 

```
Cell* create_cell( Cell_Definition& cd );
Cell* create_cell( Cell_Definition& cd )
{
	Cell* pNew = create_cell(cd.functions.instantiate_cell); 
        ...
}
``` 

At division, we would instantiate the daughter cell using the same instantiation function of the mother cell : 
```
Cell* child = create_cell(functions.instantiate_cell);
```

And last detail, to make sure that at destruction of our Cell* the potential derived destructor is called, we need to declare the Cell destructor as virtual, as well as the Basic_Agent destructor. 

Let me know what you think ! I will probably write a new PhysiMESS version with this addition next month, to be able to have the example of the two approaches, which will probably help the discussion. 