### PR TITLE
Really using the given voxel_index in remove_agent_from_voxel

### DIFF
--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -349,10 +349,12 @@ void Cell_Container::remove_agent_from_voxel(Cell* agent, int voxel_index)
 	{
 		delete_index++; 
 	}
-	// move last item to index location  
-	agent_grid[agent->get_current_mechanics_voxel_index()][delete_index] = agent_grid[agent->get_current_mechanics_voxel_index()][agent_grid[agent->get_current_mechanics_voxel_index()].size()-1 ]; 
-	// shrink the vector
-	agent_grid[agent->get_current_mechanics_voxel_index()].pop_back(); 
+	
+	// move last item to index location
+    agent_grid[voxel_index][delete_index] = agent_grid[voxel_index][agent_grid[voxel_index].size()-1 ];
+    // shrink the vector
+    agent_grid[voxel_index].pop_back();
+    
 	return; 
 }		
 


### PR DESCRIPTION
This PR modifies remove_agent_from_voxel, to actually use the voxel_index used in function's argument. This is needed when an agent span multiple voxels (such as in PhysiMESS). 


In current PhysiCell, this argument is ignored, and the current_mechanics_voxel is queried to know which voxel to remove the agent from. However, in current PhysiCell, this function is always called with the current_mechanics_voxel as argument. So this fix won't have any effect on current PhysiCell, and will allow PhysiCell extension where agents can span multiple voxels.