### PR TITLE
Adding const qualifiers to vectors operations

### DIFF
--- a/BioFVM/BioFVM_vector.cpp
+++ b/BioFVM/BioFVM_vector.cpp
@@ -498,7 +498,7 @@ void vector3_to_list( const std::vector<double>& vect , char*& buffer , char del
 	return; 
 }
 
-double dot_product( std::vector<double>& a , std::vector<double>& b )
+double dot_product( const std::vector<double>& a , const std::vector<double>& b )
 {
 	double out = 0.0; 
 	for( unsigned int i=0 ; i < a.size() ; i++ )
@@ -506,7 +506,7 @@ double dot_product( std::vector<double>& a , std::vector<double>& b )
 	return out; 
 }
 
-std::vector<double> cross_product( std::vector<double>& a , std::vector<double>& b )
+std::vector<double> cross_product( const std::vector<double>& a , const std::vector<double>& b )
 {
 	std::vector<double> out( 3, 0.0 ); 
 	out[0] = a[1]*b[2] - a[2]*b[1]; 

--- a/BioFVM/BioFVM_vector.cpp
+++ b/BioFVM/BioFVM_vector.cpp
@@ -319,7 +319,7 @@ void randomize( std::vector<double>* v )
 
 /* axpy and related BLAS-type operations */ 
 
-void axpy( std::vector<double>* y, double& a , std::vector<double>& x )
+void axpy( std::vector<double>* y, const double& a , const std::vector<double>& x )
 {
  for( unsigned int i=0; i < (*y).size() ; i++ )
  {
@@ -328,7 +328,7 @@ void axpy( std::vector<double>* y, double& a , std::vector<double>& x )
  return ; 
 }
 
-void axpy( std::vector<double>* y, std::vector<double>& a , std::vector<double>& x )
+void axpy( std::vector<double>* y, const std::vector<double>& a , const std::vector<double>& x )
 {
  for( unsigned int i=0; i < (*y).size() ; i++ )
  {
@@ -337,7 +337,7 @@ void axpy( std::vector<double>* y, std::vector<double>& a , std::vector<double>&
  return; 
 }
 
-void naxpy( std::vector<double>* y, double& a , std::vector<double>& x )
+void naxpy( std::vector<double>* y, const double& a , const std::vector<double>& x )
 {
  for( unsigned int i=0; i < (*y).size() ; i++ )
  {
@@ -346,7 +346,7 @@ void naxpy( std::vector<double>* y, double& a , std::vector<double>& x )
  return ; 
 }
 
-void naxpy( std::vector<double>* y, std::vector<double>& a , std::vector<double>& x )
+void naxpy( std::vector<double>* y, const std::vector<double>& a , const std::vector<double>& x )
 {
  for( unsigned int i=0; i < (*y).size() ; i++ )
  {

--- a/BioFVM/BioFVM_vector.h
+++ b/BioFVM/BioFVM_vector.h
@@ -141,9 +141,9 @@ void vector_to_list( const std::vector<double>& vect , char*& buffer , char deli
 
 void vector3_to_list( const std::vector<double>& vect , char*& buffer , char delim ); 
 
-double dot_product( std::vector<double>& a , std::vector<double>& b ); 
-std::vector<double> cross_product( std::vector<double>& a , std::vector<double>& b );
-
+double dot_product( const std::vector<double>& a , const std::vector<double>& b );
+std::vector<double> cross_product( const std::vector<double>& a , const std::vector<double>& b );
+    
 };
 
 #endif

--- a/BioFVM/BioFVM_vector.h
+++ b/BioFVM/BioFVM_vector.h
@@ -103,14 +103,14 @@ void randomize( std::vector<double>* v );
 /* axpy and related BLAS-type operations */ 
 
 // y = y + a*x 
-void axpy( std::vector<double>* y, double& a , std::vector<double>& x );
+void axpy( std::vector<double>* y, const double& a , const std::vector<double>& x );
 // y = y + a.*x
-void axpy( std::vector<double>* y, std::vector<double>& a , std::vector<double>& x ); 
+void axpy( std::vector<double>* y, const std::vector<double>& a , const std::vector<double>& x ); 
 
 // y = y - a*x 
-void naxpy( std::vector<double>* y, double& a , std::vector<double>& x );
+void naxpy( std::vector<double>* y, const double& a , const std::vector<double>& x );
 // y = y - a.*x
-void naxpy( std::vector<double>* y, std::vector<double>& a , std::vector<double>& x ); 
+void naxpy( std::vector<double>* y, const std::vector<double>& a , const std::vector<double>& x ); 
 
 /* I may cut these from the final version */ 
 /* CLEANUP BEFORE RELEASE */ 


### PR DESCRIPTION
There was four operations lacking the const qualifiers on their arguments : 
- axpy and naxpy
- the newly added dot_product and cross_product. 