### PR TITLE
Added custom functions to plot the agent SVG and legend

### DIFF
--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -501,6 +501,11 @@ class Cell_Functions
 	void (*molecular_model_function)(Cell* pCell, Phenotype& phenotype , double dt ); 
 */
 	
+	
+	void (*plot_agent_SVG)(std::ofstream& os, Cell* pCell, double z_slice, std::vector<std::string> (*cell_coloring_function)(Cell*), double X_lower, double Y_lower);
+	void (*plot_agent_legend)(std::ofstream& os, Cell_Definition* cell_def, double& cursor_x, double& cursor_y, std::vector<std::string> (*cell_coloring_function)(Cell*), double temp_cell_radius);
+
+	
 	Cell_Functions(); // done 
 };
 

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -67,6 +67,7 @@
 
 #include "PhysiCell_standard_models.h" 
 #include "PhysiCell_cell.h" 
+#include "../modules/PhysiCell_pathology.h"
 
 namespace PhysiCell{
 	
@@ -758,6 +759,9 @@ void initialize_default_cell_definition( void )
 	cell_defaults.functions.calculate_distance_to_membrane = NULL; 
 	
 	cell_defaults.functions.set_orientation = NULL;
+	
+	cell_defaults.functions.plot_agent_SVG = standard_agent_SVG;
+	cell_defaults.functions.plot_agent_legend = standard_agent_legend;
 	
 	// add the standard death models to the default phenotype. 
 	cell_defaults.phenotype.death.add_death_model( 0.00319/60.0 , &apoptosis , apoptosis_parameters );

--- a/modules/PhysiCell_pathology.cpp
+++ b/modules/PhysiCell_pathology.cpp
@@ -657,15 +657,8 @@ void SVG_plot( std::string filename , Microenvironment& M, double z_slice , doub
 	{
 		Cell* pC = (*all_cells)[i]; // global_cell_list[i]; 
   
-		static std::vector<std::string> Colors; 
 		if( fabs( (pC->position)[2] - z_slice ) < pC->phenotype.geometry.radius )
 		{
-			double r = pC->phenotype.geometry.radius ; 
-			double rn = pC->phenotype.geometry.nuclear_radius ; 
-			double z = fabs( (pC->position)[2] - z_slice) ; 
-   
-			Colors = cell_coloring_function( pC ); 
-
 			os << "   <g id=\"cell" << pC->ID << "\" " 
 			<< "type=\"" << pC->type_name << "\" "; // new April 2022  
 			if( pC->phenotype.death.dead == true )
@@ -673,22 +666,11 @@ void SVG_plot( std::string filename , Microenvironment& M, double z_slice , doub
 			else
 			{ os << "dead=\"false\" " ; } 
 			os << ">" << std::endl; 
-  
-			// figure out how much of the cell intersects with z = 0 
-   
-			double plot_radius = sqrt( r*r - z*z ); 
+			
+			pC->functions.plot_agent_SVG(os, pC, z_slice, cell_coloring_function, X_lower, Y_lower);
 
-			Write_SVG_circle( os, (pC->position)[0]-X_lower, (pC->position)[1]-Y_lower, 
-				plot_radius , 0.5, Colors[1], Colors[0] ); 
+			os << "  </g>" << std::endl; 
 
-			// plot the nucleus if it, too intersects z = 0;
-			if( fabs(z) < rn && PhysiCell_SVG_options.plot_nuclei == true )
-			{   
-				plot_radius = sqrt( rn*rn - z*z ); 
-			 	Write_SVG_circle( os, (pC->position)[0]-X_lower, (pC->position)[1]-Y_lower, 
-					plot_radius, 0.5, Colors[3],Colors[2]); 
-			}					  
-			os << "   </g>" << std::endl;
 		}
 		
 	}
@@ -770,6 +752,30 @@ void SVG_plot( std::string filename , Microenvironment& M, double z_slice , doub
  
 	return; 
 }
+
+void standard_agent_SVG(std::ofstream& os, PhysiCell::Cell* pC, double z_slice, std::vector<std::string> (*cell_coloring_function)(Cell*), double X_lower, double Y_lower) {
+
+	double r = pC->phenotype.geometry.radius ; 
+	double rn = pC->phenotype.geometry.nuclear_radius ; 
+	double z = fabs( (pC->position)[2] - z_slice) ; 
+
+	std::vector<std::string> Colors = cell_coloring_function( pC ); 
+	
+	// figure out how much of the cell intersects with z = 0
+	double plot_radius = sqrt( r*r - z*z );
+
+	// then normal cell, plot sphere if it intersects z = 0;
+	Write_SVG_circle( os, (pC->position)[0]-X_lower, (pC->position)[1]-Y_lower,
+						plot_radius , 0.5, Colors[1], Colors[0] );
+	// plot the nucleus if it, too intersects z = 0;
+	if( fabs(z) < rn && PhysiCell_SVG_options.plot_nuclei == true )
+	{
+		plot_radius = sqrt( rn*rn - z*z );
+		Write_SVG_circle( os, (pC->position)[0]-X_lower, (pC->position)[1]-Y_lower,
+							plot_radius, 0.5, Colors[3],Colors[2]);
+	}
+}
+
 
 std::vector<std::string> paint_by_density_percentage( double concentration, double max_conc, double min_conc ){
 
@@ -898,20 +904,10 @@ void create_plot_legend( std::string filename , std::vector<std::string> (*cell_
 	
 	for( int k=0 ; k < number_of_cell_types ; k++ )
 	{
-		// switch to the cell type 
-		Cell C; 
-		C.convert_to_cell_definition( *(cell_definitions_by_index[k]) );
-		
-		// get the colors using the current coloring function 
-		std::vector<std::string> colors = cell_coloring_function(&C); 
-		
-		// place a big circle with cytoplasm colors 
-		Write_SVG_circle(os,cursor_x, cursor_y , temp_cell_radius , 1.0 , colors[1] , colors[0] ); 
-		// place a small circle with nuclear colors 
-		Write_SVG_circle(os,cursor_x, cursor_y , 0.5*temp_cell_radius , 1.0 , colors[3] , colors[2] ); 
-		
-		// place the label 
-		
+		Cell_Definition* cell_def = cell_definitions_by_index[k];
+		cell_def->functions.plot_agent_legend(os, cell_def, cursor_x, cursor_y, cell_coloring_function, temp_cell_radius);
+				
+		// place the label
 		cursor_x += temp_cell_radius + 2*padding; 
 		cursor_y += 0.3*font_size; 
 		
@@ -927,6 +923,22 @@ void create_plot_legend( std::string filename , std::vector<std::string> (*cell_
 	
 	Write_SVG_end( os ); 
 	os.close(); 
+}
+
+void standard_agent_legend(std::ofstream& os, Cell_Definition* cell_definition, double& cursor_x, double& cursor_y, std::vector<std::string> (*cell_coloring_function)(Cell*), double temp_cell_radius) {
+	
+	// switch to the cell type 
+	Cell C; 
+	C.convert_to_cell_definition( *cell_definition );
+	
+	// get the colors using the current coloring function 
+	std::vector<std::string> colors = cell_coloring_function(&C); 	
+
+	// place a big circle with cytoplasm colors 
+	Write_SVG_circle(os,cursor_x, cursor_y , temp_cell_radius , 1.0 , colors[1] , colors[0] ); 
+	// place a small circle with nuclear colors 
+	Write_SVG_circle(os,cursor_x, cursor_y , 0.5*temp_cell_radius , 1.0 , colors[3] , colors[2] ); 
+
 }
 
 };

--- a/modules/PhysiCell_pathology.h
+++ b/modules/PhysiCell_pathology.h
@@ -127,6 +127,9 @@ void SVG_plot_with_stroma( std::string filename , Microenvironment& M, double z_
 	
 void create_plot_legend( std::string filename , std::vector<std::string> (*cell_coloring_function)(Cell*) ); 
 
+void standard_agent_SVG(std::ofstream& os, PhysiCell::Cell* pCell, double z_slice, std::vector<std::string> (*cell_coloring_function)(Cell*), double X_lower, double Y_lower);
+void standard_agent_legend(std::ofstream& os, Cell_Definition* cell_definition, double& cursor_x, double& cursor_y, std::vector<std::string> (*cell_coloring_function)(Cell*), double temp_cell_radius);
+
 };
 
 #endif

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
@@ -84,7 +84,10 @@ void create_cell_types( void )
 	   
 	   This is a good place to set default functions. 
 	*/ 
-	
+
+	initialize_default_cell_definition(); 
+	cell_defaults.phenotype.secretion.sync_to_microenvironment( &microenvironment ); 
+
 	cell_defaults.functions.volume_update_function = standard_volume_update_function;
 	cell_defaults.functions.update_velocity = NULL;
 


### PR DESCRIPTION
For PhysiMeSS, we need new design for our fibers in the svg files (a rectangle). To achieve this, we need to modify both the plotting of the svg plot, and of its legend. 

This PR introduce custom functions for the plotting of the SVG agent and of the agent's legend. The existing functions are now inside standard functions, and are still used automatically. But users now have the choice to choose a different function to plot them, by modifying the function pointer inside the Cell_Functions data structure. 