### PR TITLE
Added const accessor to previous_velocity in Basic_Agent

### DIFF
--- a/BioFVM/BioFVM_basic_agent.cpp
+++ b/BioFVM/BioFVM_basic_agent.cpp
@@ -300,6 +300,10 @@ double Basic_Agent::get_total_volume()
 	return volume;
 }
 
+const std::vector<double>& Basic_Agent::get_previous_velocity( void ) {
+	return previous_velocity;
+}
+
 void Basic_Agent::simulate_secretion_and_uptake( Microenvironment* pS, double dt )
 {
 	if(!is_active)

--- a/BioFVM/BioFVM_basic_agent.h
+++ b/BioFVM/BioFVM_basic_agent.h
@@ -125,6 +125,8 @@ class Basic_Agent
 	std::vector<double>& nearest_gradient( int substrate_index );
 	// directly access a vector of gradients, one gradient per substrate 
 	std::vector<gradient>& nearest_gradient_vector( void ); 
+	
+	const std::vector<double>& get_previous_velocity( void );
 };
 
 extern std::vector<Basic_Agent*> all_basic_agents; 


### PR DESCRIPTION
In PhysiMeSS we wanted to have a way to check if the cells are stuck between fibers, so we needed a way to access the value of the velocity computed in update_velocity. 
Since velocity is set back to zero at the end of update_position, but stored in a private variable of Basic_Agent called previous_velocity, we added a const accessor to this variable. 
