### PR TITLE
Checking that cell is not dead before running the intracellular update

### DIFF
--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -144,7 +144,7 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 	#pragma omp parallel for 
 	for( int i=0; i < (*all_cells).size(); i++ )
 	{
-		if( (*all_cells)[i]->is_out_of_domain == false && initialzed ) {
+		if( (*all_cells)[i]->is_out_of_domain == false && !(*all_cells)[i]->phenotype.death.dead && initialzed ) {
 
 			if( (*all_cells)[i]->phenotype.intracellular != NULL  && (*all_cells)[i]->phenotype.intracellular->need_update())
 			{


### PR DESCRIPTION
I just discovered a problem with PhysiBoSS and intracellular models in general : The model keeps running even after cell started dying. 
So I'm adding this simple fix, where I'm checking if the cell is not dead before updating the intracellular model. 