### PR TITLE
Fix typo in cell_rules.csv

### DIFF
--- a/sample_projects/rules_sample/config/cell_rules.csv
+++ b/sample_projects/rules_sample/config/cell_rules.csv
@@ -24,7 +24,7 @@ M2 macrophage,necrotic debris,decreases,migration speed,0.1,0.005,4,0
 M2 macrophage,volume,decreases,phagocytose dead cell,0.0,6000,4,0
 // effector cells 
 effector T cell,pro-inflammatory factor,increases,attack malignant epithelial cell,0.01,1,4,0
-effector T cell,contact with malignant epithelial cell,decreases migration speed,0.01,0.1,10,0
+effector T cell,contact with malignant epithelial cell,decreases, migration speed,0.01,0.1,10,0
 effector T cell,pro-inflammatory factor,increases,migration speed,1,0.01,4,0
 effector T cell,anti-inflammatory factor,increases,transform to exhausted T cell,0.001,0.5,4,0
 // exhausted cells 


### PR DESCRIPTION
It seems there should be a comma in Line 27 in "decreases migration speed". That would make it fit with the syntax in all the other rows.