### PR TITLE
Checking if the cell is dead before running the PhysiBoSS mapping update

### DIFF
--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -68,10 +68,12 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 	}
 
 	void update(PhysiCell::Cell * cell, PhysiCell::Phenotype& phenotype, double dt) {
-		this->update_inputs(cell, phenotype, dt);
-		this->maboss.run_simulation();
-		this->update_outputs(cell, phenotype, dt);
-		this->next_physiboss_run += this->maboss.get_time_to_update();
+		if (!cell->phenotype.death.dead) {
+			this->update_inputs(cell, phenotype, dt);
+			this->maboss.run_simulation();
+			this->update_outputs(cell, phenotype, dt);
+			this->next_physiboss_run += this->maboss.get_time_to_update();
+		}
 	}
 	
 	bool need_update() {


### PR DESCRIPTION
I just discovered a detail with PhysiBoSS and intracellular models in general : The model keeps running even after cell started dying. 
This was posing a problem with a model with mapping modifying the cell cycle rates (since the cell cycle model is replace by the death model at death).
This might be useful in some cases, so for now I prefer only preventing it in the case of the automatic mapping update of PhysiBoSS. 