### PR TITLE
Better legend division and bug fixed when plotting substrate

### DIFF
--- a/modules/PhysiCell_pathology.cpp
+++ b/modules/PhysiCell_pathology.cpp
@@ -486,13 +486,14 @@ void SVG_plot( std::string filename , Microenvironment& M, double z_slice , doub
   
 	double half_voxel_size = voxel_size / 2.0; 
 	double normalizer = 78.539816339744831 / (voxel_size*voxel_size*voxel_size); 
- 
+
+	// used for the legend
+	double max_conc;
+	double min_conc;
  // color in the background ECM
 	if(PhysiCell_settings.enable_substrate_plot == true && (*substrate_coloring_function) != NULL)
 	{
 		double dz_stroma = M.mesh.dz;
-		double max_conc;
-		double min_conc;
 
 		std::string sub = PhysiCell_settings.substrate_to_monitor;
 		int sub_index = M.find_density_index(sub); // check the substrate does actually exist
@@ -554,47 +555,6 @@ void SVG_plot( std::string filename , Microenvironment& M, double z_slice , doub
 
 			}
 
-			// add legend for the substrate
-
-			os << " <g id=\"legend\" " << std::endl 
-	   		   << "    transform=\"translate(0," << plot_height + 25 << ") scale(1,-1)\">" << std::endl;  //for some misterious reasons, the tissue part in the SVG is rotated so I have to re-rotate to draw
-																										  // the legend, otherwise it will be printed upside down
-			int padding = 0;
-
-			double conc_interval = (max_conc - min_conc) / 13; // setting the interval for the values in the legend. I will divide the legend in 13 parts (as in the jupyter notebook)
-
-			for(int i = 0; i <= 12; i++){ //creating 13 rectangoles for the bar, each one with a different shade of color.
-
-				double concentration_sample = min_conc + (conc_interval * i); // the color depends on the concentration, starting from the min concentration to the max (which was sampled before)
-
-				std::vector< std::string > output = substrate_coloring_function(concentration_sample, max_conc, min_conc );
-
-				padding = 25 * i;
-
-				double upper_left_x = plot_width + 25.0;
-				double upper_left_y = ((plot_height - 25) / 13.0) * i; // here I set the position of each rectangole
-
-				Write_SVG_rect(os, upper_left_x, plot_height - upper_left_y - 60, 25.0, ((plot_height - 25.0) / 13.0), 0 , "none", output[0]); //drawing each piece of the barplot
-
-				if(i%2 == 0){ // of course I am not printing each value of the barplot, otherwise is too crowded, so just one each 2
-
-					char* szString; 
-					szString = new char [1024]; 
-
-					sprintf( szString , "- %e", concentration_sample);
-
-					Write_SVG_text( os , szString, upper_left_x + 24, plot_height - upper_left_y + 5.31, font_size , 
-						PhysiCell_SVG_options.font_color.c_str() , PhysiCell_SVG_options.font.c_str() ); // misterious values set with a trial and error approach due to OCD. But now the legend is coherent at pixel level
-
-					delete [] szString;
-
-				}
-
-			}
-
-			Write_SVG_rect(os, 25.0 + plot_width, 25.0, 25.0, plot_height - 25.0, 0.002 * plot_height , "black", "none"); // nice black contour around the legend
-
-			os << "  </g>" << std::endl; // no more rotation, restoring the tissue object in the SVG
 		}
 	}
 /* 
@@ -745,6 +705,45 @@ void SVG_plot( std::string filename , Microenvironment& M, double z_slice , doub
 
 	// draw a box around the plot window
 	Write_SVG_rect( os , 0 , top_margin, plot_width, plot_height , 0.002 * plot_height , "rgb(0,0,0)", "none" );
+
+	if(substrate_coloring_function != NULL){
+
+		// add legend for the substrate
+
+		double conc_interval = (max_conc - min_conc) / 10; // setting the interval for the values in the legend.
+	
+		szString = new char [1024]; 
+		double upper_left_x = plot_width + 25.0;
+		double sub_rect_height = (plot_height - 25.0) / 10.0;
+		for(int i = 0; i <= 9; i++){ //creating 10 rectangoles for the bar, each one with a different shade of color.
+
+			double concentration_sample = min_conc + (conc_interval * (9-i)); // the color depends on the concentration, starting from the min concentration to the max (which was sampled before)
+
+			std::vector< std::string > output = substrate_coloring_function(concentration_sample, max_conc, min_conc );
+
+			double upper_left_y = sub_rect_height * i; // here I set the position of each rectangole
+
+			Write_SVG_rect(os, upper_left_x, top_margin + upper_left_y, 25.0, sub_rect_height, 0.002 * plot_height , "none", output[0]); //drawing each piece of the barplot
+
+			if(i%2 != 0){ // of course I am not printing each value of the barplot, otherwise is too crowded, so just one each 2
+
+				sprintf( szString , " %.2g", concentration_sample);
+				Write_SVG_rect(os, upper_left_x + 25, top_margin + upper_left_y + sub_rect_height - (0.001 * plot_height), 3, 0.002 * plot_height, 0 , "rgb(0,0,0)", "rgb(0,0,0)");
+				Write_SVG_text( os , szString, upper_left_x + 28, top_margin + upper_left_y + sub_rect_height, font_size , 
+					PhysiCell_SVG_options.font_color.c_str() , PhysiCell_SVG_options.font.c_str() ); // misterious values set with a trial and error approach due to OCD. But now the legend is coherent at pixel level
+			}
+		}
+
+		sprintf( szString , "%.2g", max_conc);
+			
+		Write_SVG_rect(os, upper_left_x + 25, top_margin - (0.001 * plot_height), 3, 0.002 * plot_height, 0 , "rgb(0,0,0)", "rgb(0,0,0)");
+		Write_SVG_text( os , szString, upper_left_x + 28, top_margin, font_size , 
+			PhysiCell_SVG_options.font_color.c_str() , PhysiCell_SVG_options.font.c_str() ); // misterious values set with a trial and error approach due to OCD. But now the legend is coherent at pixel level
+
+		delete [] szString;
+	}
+	
+	Write_SVG_rect(os, 25.0 + plot_width, top_margin, 25.0, plot_height - 25, 0.002 * plot_height , "black", "none"); // nice black contour around the legend
 	
 	// close the svg tag, close the file
 	Write_SVG_end( os ); 


### PR DESCRIPTION
Hello Paul!

I have modified the original code for plotting the substrates directly in the SVG:

1) The legend is no longer divided in 13 small rectangles but in 10 (better for proportions in general, even though 13 is a beautiful prime number)

2) Now the legend is compatible with any kind of domain set by the User.