### PR TITLE
Fixed inheritance of intracellular from default dell definition

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -3012,7 +3012,11 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 		}
 #endif
 
-	}	
+	} else{
+
+		pCD->phenotype.intracellular = NULL;
+
+	}
 
 	// set up custom data 
 	node = cd_node.child( "custom_data" );


### PR DESCRIPTION
Hello Paul!

I have added in PhysiCell_cell.cpp an if/else sentence to set to NULL phenotype.intracellular in case one or more cell definitions in the xml have no intracellular module.

Since in the GUI we do not want any inheritance from one cell definition to another, we need to make sure that in mixed models (where some cell types have a maboss model and other ones don't) cell types with no maboss model will not inherit from previous ones, and so phenotype.intracellular will stay == NULL.

I hope this explanation is not too much confusing, otherwise I can try to explain myself better...