### PR TITLE
Fix/ode energy default initialization

### DIFF
--- a/sample_projects_intracellular/ode/ode_energy/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/ode/ode_energy/custom_modules/custom.cpp
@@ -87,6 +87,9 @@ void create_cell_types( void )
 	   This is a good place to set default functions. 
 	*/ 
 	
+	initialize_default_cell_definition(); 
+	cell_defaults.phenotype.secretion.sync_to_microenvironment( &microenvironment ); 
+	
 	cell_defaults.functions.volume_update_function = standard_volume_update_function;
 	cell_defaults.functions.update_velocity = standard_update_cell_velocity;
 


### PR DESCRIPTION
Found the issue, it was missing these two lines at the beginning of create_cell_types : 

```	
	initialize_default_cell_definition(); 
	cell_defaults.phenotype.secretion.sync_to_microenvironment( &microenvironment ); 
```

I'm not sure it **should** be there, or of I need to set the standard plotting functions in another place than ```initialize_default_cell_definitions```. 

But if it's not called, then the plotting function pointers are null, and we are not protected against that. So maybe I should add an error message in this case ?