### PR TITLE
Bumped PhysiBoSS version to 2.2.1

### DIFF
--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -10,7 +10,7 @@
 #include "maboss_network.h"
 #include "utils.h"
 
-static std::string PhysiBoSS_Version = "2.2.0"; 
+static std::string PhysiBoSS_Version = "2.2.1"; 
 
 class MaBoSSIntracellular : public PhysiCell::Intracellular {
  private:


### PR DESCRIPTION
Changelog : 
- PhysiBoSS model no longer updates after cell death
- Cell definitions who don't declare an intracellular model won't automatically inherit the intracellular model of the default cell definition