### PR TITLE
Now using save_PhysiCell_to_MultiCellDS_v2 in PhysiBoSS Cell Lines

### DIFF
--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
@@ -147,7 +147,7 @@ int main( int argc, char* argv[] )
 	char filename[1024];
 	sprintf( filename , "%s/initial" , PhysiCell_settings.folder.c_str() ); 
 	
-	save_PhysiCell_to_MultiCellDS_xml_pugi( filename , microenvironment , PhysiCell_globals.current_time ); 
+	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
 	
 	sprintf( filename , "%s/states_initial.csv", PhysiCell_settings.folder.c_str());
 	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells);
@@ -202,7 +202,7 @@ int main( int argc, char* argv[] )
 				{	
 					sprintf( filename , "%s/output%08u" , PhysiCell_settings.folder.c_str(),  PhysiCell_globals.full_output_index ); 
 					
-					save_PhysiCell_to_MultiCellDS_xml_pugi( filename , microenvironment , PhysiCell_globals.current_time ); 
+					save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
 					
 					sprintf( filename , "%s/states_%08u.csv", PhysiCell_settings.folder.c_str(), PhysiCell_globals.full_output_index);
 					
@@ -257,7 +257,7 @@ int main( int argc, char* argv[] )
 	// save a final simulation snapshot 
 	
 	sprintf( filename , "%s/final" , PhysiCell_settings.folder.c_str() ); 
-	save_PhysiCell_to_MultiCellDS_xml_pugi( filename , microenvironment , PhysiCell_globals.current_time ); 
+	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
 	
 	sprintf( filename , "%s/states_final.csv", PhysiCell_settings.folder.c_str());
 	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );


### PR DESCRIPTION
@johnmetzcar notified me I was still using the old function to export the mat files in the PhysiBoSS sample project. 
Here is the fix !