### PR TITLE
Fixed inhibiting behaviors and cleaning. Updated version to 2.2.2

### DIFF
--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -10,7 +10,7 @@
 #include "maboss_network.h"
 #include "utils.h"
 
-static std::string PhysiBoSS_Version = "2.2.1"; 
+static std::string PhysiBoSS_Version = "2.2.2"; 
 
 class MaBoSSIntracellular : public PhysiCell::Intracellular {
  private:

--- a/addons/PhysiBoSS/src/utils.h
+++ b/addons/PhysiBoSS/src/utils.h
@@ -81,34 +81,48 @@ public:
     double value;
     double base_value;
     int smoothing;
-    double smoothed_value;
+    double probability;
+    bool initialized = false;
 
-    MaBoSSOutput(std::string physicell_name, std::string intracellular_name, std::string action, double value, double base_value, int smoothing) : physicell_name(physicell_name), intracellular_name(intracellular_name), action(action), value(value), base_value(base_value), smoothing(smoothing) {
-        smoothed_value = base_value;
+    MaBoSSOutput(std::string physicell_name, std::string intracellular_name,
+                std::string action, double value, double base_value,
+                int smoothing)
+        : physicell_name(physicell_name), intracellular_name(intracellular_name),
+        action(action), value(value), base_value(base_value),
+        smoothing(smoothing) {
+    probability = 0.5;
     }
 
-    void update_value(bool test) {
-        smoothed_value = (smoothed_value*smoothing + (test?1.0:0.0)) / (smoothing + 1.0);
+    double update_probability(bool test) {
+    if (!initialized) {
+        probability = test;
+        initialized = true;
+    } else
+        probability =
+            (probability * smoothing + (test ? 1.0 : 0.0)) / (smoothing + 1.0);
+
+    return probability;
     }
 
-    double update(bool test)
-    {
-        double true_value;
-        if (smoothing == 0) {
-            true_value = value;
-        } else {
-            update_value((action == "activation" && test) || (action == "inhibition" and !test));
-            true_value = smoothed_value;
-        }
+    double update(bool test) {
 
-        if (action == "activation" && test) {
-            double hill = PhysiCell::Hill_response_function( true_value*2 , 1 , 10 ); 
-            return (value-base_value)*hill+base_value;
-        } else if (action == "inhibition" && !test) {
-            double hill = PhysiCell::Hill_response_function( true_value*2 , 1 , 10 ); 
-            return value-(value-base_value)*hill;
-        }
-        return base_value;
+    double hill_input;
+
+    if (smoothing == 0) {
+        hill_input = test ? 1.0 : 0.0;
+    } else {
+        hill_input = update_probability(test);
+    }
+
+    if (action == "activation") {
+        double hill = PhysiCell::Hill_response_function(hill_input * 2, 1, 10);
+        return (value - base_value) * hill + base_value;
+    } else if (action == "inhibition") {
+        double hill = PhysiCell::Hill_response_function(hill_input * 2, 1, 10);
+        return ((value - base_value) * (1 - hill)) + base_value;
+    }
+
+    return base_value;
     }
 };
 #endif


### PR DESCRIPTION
Hello Paul! 

In this pull request I am correcting a bug that is preventing the inhibition of a behavior to work in PhysiBoSS. 
Previously, when an output node was connected to a behavior with action == inhibition, this was actually not working because the formula was not correct. Moreover, we removed the "test" variable from the if sentences when checking for the action, which was causing confusion and was not useful.

In a future pull request, I am planning to make the Hill exponent (now set to 10), as a parameter for the user, to give the user the possibility to choose between a step-like Hill function or a smoother one.

Please if you have any concern or doubt do not hesitate to let me know!