### PR TITLE
Removing default phenotype function in physiboss cell lines example

### DIFF
--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
@@ -90,7 +90,7 @@ void create_cell_types( void )
 
 	cell_defaults.functions.volume_update_function = standard_volume_update_function;
 	cell_defaults.functions.update_velocity = NULL;
-
+	cell_defaults.functions.update_phenotype = NULL; 
 	cell_defaults.functions.update_migration_bias = NULL; 
 	cell_defaults.functions.pre_update_intracellular = pre_update_intracellular; 
 	cell_defaults.functions.post_update_intracellular = post_update_intracellular; 


### PR DESCRIPTION
Just found out that PhysiBoSS cell lines example was using the default update_phenotype function, while it shouldn't.