### PR TITLE
Using a unique function to save both MultiCellDS data and intracellular data

### DIFF
--- a/addons/PhysiBoSS/src/maboss_intracellular.cpp
+++ b/addons/PhysiBoSS/src/maboss_intracellular.cpp
@@ -473,14 +473,14 @@ void MaBoSSIntracellular::display(std::ostream& os)
 	std::cout << std::endl;
 }
 
-void MaBoSSIntracellular::save(std::string filename, std::vector<PhysiCell::Cell*>& cells)
+void MaBoSSIntracellular::save(std::string filename)
 {
 	std::ofstream state_file( filename );
 	
 	state_file << "ID,state" << std::endl;
 
-	for( auto cell : cells )
-		if (cell->phenotype.intracellular != NULL)
+	for( auto cell : *PhysiCell::all_cells )
+		if (cell->phenotype.intracellular != NULL && cell->phenotype.intracellular->intracellular_type == "maboss")
 			state_file << cell->ID << "," << static_cast<MaBoSSIntracellular*>(cell->phenotype.intracellular)->get_state() << std::endl;
 	
 	state_file.close();

--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -120,7 +120,7 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
 
 	void display(std::ostream& os);
 	
-	static void save(std::string filename, std::vector<PhysiCell::Cell*>& cells);
+	static void save(std::string filename);
 
     // unneeded for this type
     int update_phenotype_parameters(PhysiCell::Phenotype& phenotype) {return 0;}

--- a/modules/PhysiCell_MultiCellDS.cpp
+++ b/modules/PhysiCell_MultiCellDS.cpp
@@ -66,7 +66,9 @@
 */
  
 #include "PhysiCell_MultiCellDS.h"
-
+#ifdef ADDON_PHYSIBOSS
+#include "../addons/PhysiBoSS/src/maboss_intracellular.h"	
+#endif
 namespace PhysiCell{
 
 void add_PhysiCell_cell_to_open_xml_pugi(  pugi::xml_document& xml_dom, Cell& C ); // not implemented -- future edition 
@@ -1937,6 +1939,60 @@ void add_PhysiCell_cells_to_open_xml_pugi_v2( pugi::xml_document& xml_dom, std::
 	}
 
 	fclose( fp ); 
+
+#ifdef ADDON_PHYSIBOSS
+
+	// PhysiBoSS Intracellular Data
+	node = node.parent().parent();  // custom 
+
+	root = node; 
+	node = node.child( "boolean_intracellular_data" );  
+	if( !node )
+	{
+		node = root.append_child( "boolean_intracellular_data" ); 
+
+		pugi::xml_attribute attrib = node.append_attribute( "type" ); 
+		attrib.set_value( "text" ); 		
+
+		attrib = node.append_attribute( "source" ); 
+		attrib.set_value( "PhysiBoSS" ); 		
+
+		attrib = node.append_attribute( "data_version" ); 
+		attrib.set_value( "2" ); 	
+	}
+	root = node; // root = cellular_information.cell_populations.cell_population.custom.intracellular_data
+	node = root.child( "filename"); 
+	if( !node )
+	{
+		node = root.append_child( "filename" ); 
+
+	}
+	root = node; // root = cellular_information.cell_populations.cell_population.custom.intracellular_data.filename
+
+
+	// next, filename 
+	sprintf( filename , "%s_boolean_intracellular.csv" , filename_base.c_str() ); 
+		
+	/* store filename without the relative pathing (if any) */ 
+	filename_start = strrchr( filename , '/' ); 
+	if( filename_start == NULL )
+	{ filename_start = filename; }
+	else	
+	{ filename_start++; } 
+	strcpy( filename_without_pathing , filename_start );  
+	
+	if( !node.first_child() )
+	{
+		node.append_child( pugi::node_pcdata ).set_value( filename_without_pathing ); // filename ); 
+	}
+	else
+	{
+		node.first_child().set_value( filename_without_pathing ); // filename ); 
+	}	
+
+	MaBoSSIntracellular::save( filename );
+
+#endif
 
 	// neighbor graph 
 	node = node.parent().parent();  // custom 

--- a/sample_projects_intracellular/boolean/cancer_invasion/main.cpp
+++ b/sample_projects_intracellular/boolean/cancer_invasion/main.cpp
@@ -150,9 +150,6 @@ int main( int argc, char* argv[] )
 	sprintf( filename , "%s/initial" , PhysiCell_settings.folder.c_str() ); 
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
 	
-	sprintf( filename , "%s/states_initial.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells);
-	
 	// save a quick SVG cross section through z = 0, after setting its 
 	// length bar to 200 microns 
 
@@ -207,10 +204,6 @@ int main( int argc, char* argv[] )
 					sprintf( filename , "%s/output%08u" , PhysiCell_settings.folder.c_str(),  PhysiCell_globals.full_output_index ); 
 					
 					save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-
-					sprintf( filename , "%s/states_%08u.csv", PhysiCell_settings.folder.c_str(), PhysiCell_globals.full_output_index);
-					
-					MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
 				}
 				
 				PhysiCell_globals.full_output_index++; 
@@ -258,9 +251,6 @@ int main( int argc, char* argv[] )
 	
 	sprintf( filename , "%s/final" , PhysiCell_settings.folder.c_str() ); 
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-	
-	sprintf( filename , "%s/states_final.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
 	
 	sprintf( filename , "%s/final.svg" , PhysiCell_settings.folder.c_str() ); 
 	SVG_plot( filename , microenvironment, 0.0 , PhysiCell_globals.current_time, cell_coloring_function, ECM_coloring_function);

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -175,8 +175,8 @@ PhysiCell_SVG.o: ./modules/PhysiCell_SVG.cpp
 PhysiCell_pathology.o: ./modules/PhysiCell_pathology.cpp
 	$(COMPILE_COMMAND) -c ./modules/PhysiCell_pathology.cpp
 
-PhysiCell_MultiCellDS.o: ./modules/PhysiCell_MultiCellDS.cpp
-	$(COMPILE_COMMAND) -c ./modules/PhysiCell_MultiCellDS.cpp
+PhysiCell_MultiCellDS.o: ./modules/PhysiCell_MultiCellDS.cpp $(MaBoSS)
+	$(COMPILE_COMMAND) $(INC) -c ./modules/PhysiCell_MultiCellDS.cpp
 
 PhysiCell_various_outputs.o: ./modules/PhysiCell_various_outputs.cpp
 	$(COMPILE_COMMAND) -c ./modules/PhysiCell_various_outputs.cpp

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
@@ -149,9 +149,6 @@ int main( int argc, char* argv[] )
 	
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
 	
-	sprintf( filename , "%s/states_initial.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells);
-	
 	// save a quick SVG cross section through z = 0, after setting its 
 	// length bar to 200 microns 
 
@@ -205,11 +202,6 @@ int main( int argc, char* argv[] )
 					sprintf( filename , "%s/output%08u" , PhysiCell_settings.folder.c_str(),  PhysiCell_globals.full_output_index ); 
 					
 					save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-					
-					sprintf( filename , "%s/states_%08u.csv", PhysiCell_settings.folder.c_str(), PhysiCell_globals.full_output_index);
-					
-					MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
-	
 				}
 				
 				PhysiCell_globals.full_output_index++; 
@@ -260,9 +252,6 @@ int main( int argc, char* argv[] )
 	
 	sprintf( filename , "%s/final" , PhysiCell_settings.folder.c_str() ); 
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-	
-	sprintf( filename , "%s/states_final.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
 	
 	sprintf( filename , "%s/final.svg" , PhysiCell_settings.folder.c_str() ); 
 	SVG_plot( filename , microenvironment, 0.0 , PhysiCell_globals.current_time, cell_coloring_function );

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
@@ -256,7 +256,6 @@ int main( int argc, char* argv[] )
 	sprintf( filename , "%s/final.svg" , PhysiCell_settings.folder.c_str() ); 
 	SVG_plot( filename , microenvironment, 0.0 , PhysiCell_globals.current_time, cell_coloring_function );
 
-	
 	// timer 
 	
 	std::cout << std::endl << "Total simulation runtime: " << std::endl; 

--- a/sample_projects_intracellular/boolean/template_BM/main.cpp
+++ b/sample_projects_intracellular/boolean/template_BM/main.cpp
@@ -143,9 +143,6 @@ int main( int argc, char* argv[] )
 	sprintf( filename , "%s/initial" , PhysiCell_settings.folder.c_str() ); 
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
 	
-	sprintf( filename , "%s/states_initial.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells);
-		
 	// save a quick SVG cross section through z = 0, after setting its 
 	// length bar to 200 microns 
 
@@ -199,9 +196,6 @@ int main( int argc, char* argv[] )
 					sprintf( filename , "%s/output%08u" , PhysiCell_settings.folder.c_str(),  PhysiCell_globals.full_output_index ); 
 					
 					save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-					sprintf( filename , "%s/states_%08u.csv", PhysiCell_settings.folder.c_str(), PhysiCell_globals.full_output_index);
-					MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
-	
 				}
 				
 				PhysiCell_globals.full_output_index++; 
@@ -252,9 +246,6 @@ int main( int argc, char* argv[] )
 	
 	sprintf( filename , "%s/final" , PhysiCell_settings.folder.c_str() ); 
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-	
-	sprintf( filename , "%s/states_final.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
 	
 	sprintf( filename , "%s/final.svg" , PhysiCell_settings.folder.c_str() ); 
 	SVG_plot( filename , microenvironment, 0.0 , PhysiCell_globals.current_time, cell_coloring_function );

--- a/sample_projects_intracellular/boolean/tutorial/main.cpp
+++ b/sample_projects_intracellular/boolean/tutorial/main.cpp
@@ -150,9 +150,6 @@ int main( int argc, char* argv[] )
 	sprintf( filename , "%s/initial" , PhysiCell_settings.folder.c_str() ); 
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
 	
-	sprintf( filename , "%s/states_initial.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells);
-	
 	// save a quick SVG cross section through z = 0, after setting its 
 	// length bar to 200 microns 
 
@@ -207,10 +204,6 @@ int main( int argc, char* argv[] )
 					sprintf( filename , "%s/output%08u" , PhysiCell_settings.folder.c_str(),  PhysiCell_globals.full_output_index ); 
 					
 					save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-
-					sprintf( filename , "%s/states_%08u.csv", PhysiCell_settings.folder.c_str(), PhysiCell_globals.full_output_index);
-					
-					MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
 				}
 				
 				PhysiCell_globals.full_output_index++; 
@@ -261,9 +254,6 @@ int main( int argc, char* argv[] )
 	
 	sprintf( filename , "%s/final" , PhysiCell_settings.folder.c_str() ); 
 	save_PhysiCell_to_MultiCellDS_v2( filename , microenvironment , PhysiCell_globals.current_time ); 
-	
-	sprintf( filename , "%s/states_final.csv", PhysiCell_settings.folder.c_str());
-	MaBoSSIntracellular::save( filename, *PhysiCell::all_cells );
 	
 	sprintf( filename , "%s/final.svg" , PhysiCell_settings.folder.c_str() ); 
 	SVG_plot( filename , microenvironment, 0.0 , PhysiCell_globals.current_time, cell_coloring_function, substrate_coloring_function );


### PR DESCRIPTION
This comes as an effort to make the main.cpp of PhysiBoSS (and ultimately intracellular) models standard. 
As of now, the only difference is that after saving the MultiCellDS data, I'm also saving a CSV PhysiBoSS state file. And if other intracellular models wants to save state, they have to do the same. 

<del>The idea here is to have a wrapper function to include MultiCellDS and intracellular data save, that I called ```save_PhysiCell_Timepoint``` and stored in ```PhysiCell_various_outputs```. </del>

<del>There will have no impact on the rest of PhysiCell, since in this PR only PhysiBoSS Cell Lines example is using this wrapper. But ultimately, it would be nice if all projects would use it, so that we get a standard main.cpp file. </del>

<del>There is no hurry for this, I just wanted to code it to see what it would look like, and have your opinion about this. </del>

At first I though about writing a wrapper to include the intracellular save with the full save, but after discussing with @elmbeech, and thinking more about this, I just need to add it to the MultiCellDS data. Here is what it would look like : 

```
<cellular_information>
	<cell_populations>
		<cell_population type="individual">
			<custom>
				...
				<intracellular_data type="text" source="PhysiBoSS" data_version="2">
					<filename>output00000002_boolean_intracellular.csv</filename>
				</intracellular_data>
				...
			</custom>
		</cell_population>
	</cell_populations>
</cellular_information>

```

The name of the tag, the filename, are completely open to suggestions.  
The filename use to be states_XXXXXXXX.csv, so it's already a breaking change for PhysiCell Studio and pcdl. I guess for them we would have to look at the XML file to see if the new intracellular_data field is there, otherwise check if the old format is there. 

Let's talk about this !