### PR TITLE
added ability to initialize BioFVM substrates with initial conditions…

### DIFF
--- a/BioFVM/BioFVM_matlab.cpp
+++ b/BioFVM/BioFVM_matlab.cpp
@@ -108,7 +108,8 @@ std::vector< std::vector<double> > read_matlab( std::string filename )
      type_data_format > 5 || // unknown format
      type_matrix_type != 0 ) // want full matrices, not sparse 
  {
-  std::cout << "Error reading file " << filename << ": I can't read this format yet!" << std::endl;
+  std::cout << "Error reading file " << filename << ": I can't read this format yet!" << std::endl
+            << "\t Make sure you save the .mat file in '-v4'" << std::endl;
   return output;
  } 
 

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -339,6 +339,10 @@ class Microenvironment_Options
 	std::vector<double> Dirichlet_zmax_values; 
 	
 	std::vector<double> initial_condition_vector; 
+
+	bool initial_condition_from_file_enabled;
+	std::string initial_condition_file_type;
+	std::string initial_condition_file;
 	
 	bool simulate_2D; 
 	std::vector<double> X_range; 
@@ -359,6 +363,7 @@ extern Microenvironment microenvironment;
 
 void initialize_microenvironment( void ); 
 
+void load_initial_conditions_from_matlab( std::string filename );
 };
 
 #endif

--- a/config/PhysiCell_settings.xml
+++ b/config/PhysiCell_settings.xml
@@ -14,7 +14,7 @@
     </domain>
 
     <overall>
-        <max_time units="min">14400</max_time>
+        <max_time units="min">7200</max_time>
         <time_units>min</time_units>
         <space_units>micron</space_units>
         <dt_diffusion units="min">0.01</dt_diffusion>
@@ -44,45 +44,14 @@
     <options>
         <legacy_random_points_on_sphere_in_divide>false</legacy_random_points_on_sphere_in_divide>
         <virtual_wall_at_domain_edge>true</virtual_wall_at_domain_edge>
+        <disable_automated_spring_adhesions>false</disable_automated_spring_adhesions>
     </options>
 
     <microenvironment_setup>
-        <variable name="oxygen" units="dimensionless" ID="0">
+        <variable name="substrate" units="dimensionless" ID="0">
             <physical_parameter_set>
                 <diffusion_coefficient units="micron^2/min">100000.0</diffusion_coefficient>
-                <decay_rate units="1/min">0.1</decay_rate>
-            </physical_parameter_set>
-            <initial_condition units="mmHg">38</initial_condition>
-            <Dirichlet_boundary_condition units="mmHg" enabled="True">0</Dirichlet_boundary_condition>
-            <Dirichlet_options>
-                <boundary_value ID="xmin" enabled="True">38</boundary_value>
-                <boundary_value ID="xmax" enabled="True">10</boundary_value>
-                <boundary_value ID="ymin" enabled="True">10</boundary_value>
-                <boundary_value ID="ymax" enabled="True">38</boundary_value>
-                <boundary_value ID="zmin" enabled="False">0</boundary_value>
-                <boundary_value ID="zmax" enabled="False">0</boundary_value>
-            </Dirichlet_options>
-        </variable>
-        <variable name="necrotic debris" units="dimensionless" ID="1">
-            <physical_parameter_set>
-                <diffusion_coefficient units="micron^2/min">10</diffusion_coefficient>
-                <decay_rate units="1/min">.1</decay_rate>
-            </physical_parameter_set>
-            <initial_condition units="mmHg">0</initial_condition>
-            <Dirichlet_boundary_condition units="mmHg" enabled="False">0</Dirichlet_boundary_condition>
-            <Dirichlet_options>
-                <boundary_value ID="xmin" enabled="False">0</boundary_value>
-                <boundary_value ID="xmax" enabled="False">0</boundary_value>
-                <boundary_value ID="ymin" enabled="False">0</boundary_value>
-                <boundary_value ID="ymax" enabled="False">0</boundary_value>
-                <boundary_value ID="zmin" enabled="False">0</boundary_value>
-                <boundary_value ID="zmax" enabled="False">0</boundary_value>
-            </Dirichlet_options>
-        </variable>
-        <variable name="apoptotic debris" units="dimensionless" ID="2">
-            <physical_parameter_set>
-                <diffusion_coefficient units="micron^2/min">10</diffusion_coefficient>
-                <decay_rate units="1/min">0.1</decay_rate>
+                <decay_rate units="1/min">10</decay_rate>
             </physical_parameter_set>
             <initial_condition units="mmHg">0</initial_condition>
             <Dirichlet_boundary_condition units="mmHg" enabled="False">0</Dirichlet_boundary_condition>
@@ -98,8 +67,8 @@
         <options>
             <calculate_gradients>true</calculate_gradients>
             <track_internalized_substrates_in_each_agent>true</track_internalized_substrates_in_each_agent>
-            <initial_condition type="matlab" enabled="false">
-                <filename>./config/initial.mat</filename>
+            <initial_condition type="matlab" enabled="true">
+                <filename>./config/ic.mat</filename>
             </initial_condition>
             <dirichlet_nodes type="matlab" enabled="false">
                 <filename>./config/dirichlet.mat</filename>
@@ -108,12 +77,15 @@
     </microenvironment_setup>
 
     <cell_definitions>
-        <cell_definition name="malignant epithelial" ID="0">
+        <cell_definition name="default" ID="0">
             <phenotype>
-                <cycle code="5" name="live">
-                    <phase_transition_rates units="1/min">
-                        <rate start_index="0" end_index="0" fixed_duration="false">0.000</rate>
-                    </phase_transition_rates>
+                <cycle code="6" name="Flow cytometry model (separated)">
+                    <phase_durations units="min">
+                        <duration index="0" fixed_duration="false">300.0</duration>
+                        <duration index="1" fixed_duration="true">480</duration>
+                        <duration index="2" fixed_duration="true">240</duration>
+                        <duration index="3" fixed_duration="true">60</duration>
+                    </phase_durations>
                 </cycle>
                 <death>
                     <model code="100" name="apoptosis">
@@ -131,7 +103,7 @@
                         </parameters>
                     </model>
                     <model code="101" name="necrosis">
-                        <death_rate units="1/min">2.80E-03</death_rate>
+                        <death_rate units="1/min">0.0</death_rate>
                         <phase_durations units="min">
                             <duration index="0" fixed_duration="true">0</duration>
                             <duration index="1" fixed_duration="true">86400</duration>
@@ -162,7 +134,7 @@
                     <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
                     <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
                     <cell_adhesion_affinities>
-                        <cell_adhesion_affinity name="malignant epithelial">1</cell_adhesion_affinity>
+                        <cell_adhesion_affinity name="default">1</cell_adhesion_affinity>
                     </cell_adhesion_affinities>
                     <options>
                         <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
@@ -183,59 +155,41 @@
                         <use_2D>true</use_2D>
                         <chemotaxis>
                             <enabled>false</enabled>
-                            <substrate>oxygen</substrate>
+                            <substrate>substrate</substrate>
                             <direction>1</direction>
                         </chemotaxis>
                         <advanced_chemotaxis>
                             <enabled>false</enabled>
                             <normalize_each_gradient>false</normalize_each_gradient>
                             <chemotactic_sensitivities>
-                                <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="necrotic debris">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="apoptotic debris">0.0</chemotactic_sensitivity>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
                 </motility>
                 <secretion>
-                    <substrate name="oxygen">
+                    <substrate name="substrate">
                         <secretion_rate units="1/min">0</secretion_rate>
                         <secretion_target units="substrate density">1</secretion_target>
-                        <uptake_rate units="1/min">10</uptake_rate>
+                        <uptake_rate units="1/min">0</uptake_rate>
                         <net_export_rate units="total substrate/min">0</net_export_rate>
-                    </substrate>
-                    <substrate name="necrotic debris">
-                        <secretion_rate units="1/min">0.0</secretion_rate>
-                        <secretion_target units="substrate density">1</secretion_target>
-                        <uptake_rate units="1/min">0.0</uptake_rate>
-                        <net_export_rate units="total substrate/min">0.0</net_export_rate>
-                    </substrate>
-                    <substrate name="apoptotic debris">
-                        <secretion_rate units="1/min">0.0</secretion_rate>
-                        <secretion_target units="substrate density">1</secretion_target>
-                        <uptake_rate units="1/min">0.0</uptake_rate>
-                        <net_export_rate units="total substrate/min">0.0</net_export_rate>
                     </substrate>
                 </secretion>
                 <cell_interactions>
                     <dead_phagocytosis_rate units="1/min">0</dead_phagocytosis_rate>
                     <live_phagocytosis_rates>
-                        <phagocytosis_rate name="malignant epithelial" units="1/min">0</phagocytosis_rate>
                         <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
                     </live_phagocytosis_rates>
                     <attack_rates>
-                        <attack_rate name="malignant epithelial" units="1/min">0</attack_rate>
                         <attack_rate name="default" units="1/min">0</attack_rate>
                     </attack_rates>
                     <damage_rate units="1/min">1</damage_rate>
                     <fusion_rates>
-                        <fusion_rate name="malignant epithelial" units="1/min">0</fusion_rate>
                         <fusion_rate name="default" units="1/min">0</fusion_rate>
                     </fusion_rates>
                 </cell_interactions>
                 <cell_transformations>
                     <transformation_rates>
-                        <transformation_rate name="malignant epithelial" units="1/min">0</transformation_rate>
                         <transformation_rate name="default" units="1/min">0</transformation_rate>
                     </transformation_rates>
                 </cell_transformations>
@@ -247,7 +201,7 @@
     </cell_definitions>
 
     <initial_conditions>
-        <cell_positions type="csv" enabled="true">
+        <cell_positions type="csv" enabled="false">
             <folder>./config</folder>
             <filename>cells.csv</filename>
         </cell_positions>
@@ -255,17 +209,16 @@
 
     <cell_rules>
         <rulesets>
-            <ruleset protocol="CBHG" version="2.0" format="csv" enabled="true">
+            <ruleset protocol="CBHG" version="2.0" format="csv" enabled="false">
                 <folder>./config</folder>
-                <filename>cell_rules_v2.csv</filename>
+                <filename>cell_rules.csv</filename>
             </ruleset>
         </rulesets>
         <settings />
     </cell_rules>
 
-
     <user_parameters>
         <random_seed type="int" units="dimensionless" description="">0</random_seed>
-        <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">0</number_of_cells>
+        <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">5</number_of_cells>
     </user_parameters>
 </PhysiCell_settings>

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -911,8 +911,19 @@ bool setup_microenvironment_from_XML( pugi::xml_node root_node )
 	
 	// track internalized substrates in each agent? 
 	default_microenvironment_options.track_internalized_substrates_in_each_agent 
-		= xml_get_bool_value( node, "track_internalized_substrates_in_each_agent" ); 
-	
+		= xml_get_bool_value( node, "track_internalized_substrates_in_each_agent" );
+
+	node = xml_find_node(node, "initial_condition");
+	if (node)
+	{
+		default_microenvironment_options.initial_condition_from_file_enabled = node.attribute("enabled").as_bool();
+		if (default_microenvironment_options.initial_condition_from_file_enabled)
+		{
+			default_microenvironment_options.initial_condition_file_type = node.attribute("type").as_string();
+			default_microenvironment_options.initial_condition_file = xml_get_string_value(node, "filename");
+		}
+	}
+
 	// not yet supported : read initial conditions 
 	/*
 	// read in initial conditions from an external file 


### PR DESCRIPTION
BioFVM substrates can be read in from a .mat file. The .mat file is a single matrix where each row is a voxel. The first three entries in the row are the x-, y-, and z- coordinates, respectively. The remaining columns are the values for ALL substrates.

Checks are made that the number of voxels (rows) is correct, number of substrates (columns - 3) is correct, and that the voxel indices corresponding to the positions in the (x,y,z) columns are all unique.

If the user wants to enable these, then simply go to the microenvironment options in the config xml, enable them, and specify the path to the .mat file relative to the PhysiCell directory.

Errors are issued with reminders about how to correctly set up the .mat file.