### PR TITLE
added ability to initialize BioFVM substrates with initial conditions

### DIFF
--- a/BioFVM/BioFVM_matlab.cpp
+++ b/BioFVM/BioFVM_matlab.cpp
@@ -108,7 +108,8 @@ std::vector< std::vector<double> > read_matlab( std::string filename )
      type_data_format > 5 || // unknown format
      type_matrix_type != 0 ) // want full matrices, not sparse 
  {
-  std::cout << "Error reading file " << filename << ": I can't read this format yet!" << std::endl;
+  std::cout << "Error reading file " << filename << ": I can't read this format yet!" << std::endl
+            << "\t Make sure you save the .mat file in '-v4'" << std::endl;
   return output;
  } 
 

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -49,6 +49,7 @@
 #ifndef __BioFVM_microenvironment_h__
 #define __BioFVM_microenvironment_h__
 
+#include <sstream>
 #include "BioFVM_mesh.h"
 #include "BioFVM_agent_container.h"
 #include "BioFVM_MultiCellDS.h"
@@ -339,6 +340,10 @@ class Microenvironment_Options
 	std::vector<double> Dirichlet_zmax_values; 
 	
 	std::vector<double> initial_condition_vector; 
+
+	bool initial_condition_from_file_enabled;
+	std::string initial_condition_file_type;
+	std::string initial_condition_file;
 	
 	bool simulate_2D; 
 	std::vector<double> X_range; 
@@ -359,6 +364,9 @@ extern Microenvironment microenvironment;
 
 void initialize_microenvironment( void ); 
 
+void load_initial_conditions_from_matlab( std::string filename );
+void load_initial_conditions_from_csv( std::string filename );
+void get_row_from_substrate_initial_condition_csv(std::vector<int> &voxel_set, const std::string line, const std::vector<int> substrate_indices, const bool header_provided);
 };
 
 #endif

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -911,8 +911,19 @@ bool setup_microenvironment_from_XML( pugi::xml_node root_node )
 	
 	// track internalized substrates in each agent? 
 	default_microenvironment_options.track_internalized_substrates_in_each_agent 
-		= xml_get_bool_value( node, "track_internalized_substrates_in_each_agent" ); 
-	
+		= xml_get_bool_value( node, "track_internalized_substrates_in_each_agent" );
+
+	node = xml_find_node(node, "initial_condition");
+	if (node)
+	{
+		default_microenvironment_options.initial_condition_from_file_enabled = node.attribute("enabled").as_bool();
+		if (default_microenvironment_options.initial_condition_from_file_enabled)
+		{
+			default_microenvironment_options.initial_condition_file_type = node.attribute("type").as_string();
+			default_microenvironment_options.initial_condition_file = xml_get_string_value(node, "filename");
+		}
+	}
+
 	// not yet supported : read initial conditions 
 	/*
 	// read in initial conditions from an external file 


### PR DESCRIPTION
BioFVM substrates can be read in from a .mat file. The .mat file is a single matrix where each row is a voxel. The first three entries in the row are the x-, y-, and z- coordinates, respectively. The remaining columns are the values for ALL substrates.

Checks are made that the number of voxels (rows) is correct, number of substrates (columns - 3) is correct, and that the voxel indices corresponding to the positions in the (x,y,z) columns are all unique.

If the user wants to enable these, then simply go to the microenvironment options in the config xml, enable them, and specify the path to the .mat file relative to the PhysiCell directory.

Errors are issued with reminders about how to correctly set up the .mat file.