### PR TITLE
Update PhysiCell_rules.cpp

### DIFF
--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -798,8 +798,8 @@ Hypothesis_Rule* Hypothesis_Ruleset::add_behavior( std::string behavior , double
 
 Hypothesis_Rule* Hypothesis_Ruleset::add_behavior( std::string behavior )
 { 
-	double min_behavior = 0.1; 
-	double max_behavior = 1.0; 
+	double min_behavior = 9e99; // Min behaviour high value
+	double max_behavior = -9e99; // Max behaviour low value
 	return Hypothesis_Ruleset::add_behavior( behavior, min_behavior, max_behavior );
 }
 
@@ -1127,8 +1127,9 @@ void set_behavior_min_value( std::string cell_type, std::string behavior, double
             << ", but no rule for this behavior found for this cell type." << std::endl; 
         exit(-1);         
     }
-
-	hypothesis_rulesets[pCD][behavior].min_value = min_value; 
+	
+	if ( min_value < hypothesis_rulesets[pCD][behavior].min_value )
+	{ hypothesis_rulesets[pCD][behavior].min_value = min_value; }
 
 	return;
 }
@@ -1160,7 +1161,8 @@ void set_behavior_max_value( std::string cell_type, std::string behavior, double
         exit(-1);         
     }
 
-	hypothesis_rulesets[pCD][behavior].max_value = max_value;
+	if ( max_value > hypothesis_rulesets[pCD][behavior].max_value )
+	{ hypothesis_rulesets[pCD][behavior].max_value = max_value; }
 	
 	return;
 }


### PR DESCRIPTION
Bug fixed: Previously in a scenario with multiple rules in the same response (increase or decrease) the last rule defined the max/min response value of behavior. Right now, it checks the min/max response value for all rules of the same behavior.