### PR TITLE
Script to provide pre-compiled binaries, built by GitHub actions, for linux/mac/windows

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_name: ${{ matrix.projects.short_name }}-linux.tar.gz
-        asset_path: ${{ github.workspace }}/${{ matrix.projects.short_name }}.tar.gz
+        asset_path: ${{ github.workspace }}/${{ matrix.projects.short_name }}-linux.tar.gz
         asset_content_type: application/gzip   
         
         

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -1,0 +1,262 @@
+name: Build binaries
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [created]
+    
+jobs:
+         
+  ubuntu:
+    strategy:
+      matrix:
+        projects: [
+          {short_name: "physiboss-tutorial", project: "physiboss-tutorial", name: "PhysiBoSS tutorial", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-tutorial-invasion", project: "physiboss-tutorial-invasion", name: "PhysiBoSS Cancer Invasion", binary: "invasion_model", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-cell-lines", project: "physiboss-cell-lines-sample", name: "PhysiBoSS Cell Lines", binary: "PhysiBoSS_Cell_Lines", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template_BM", project: "template_BM", name: "PhysiBoSS Template", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template", project: "template", name: "PhysiCell Template", binary: "project", extra_run: ""},
+          {short_name: "rules", project: "rules-sample", name: "PhysiCell Rules", binary: "project", extra_run: ""},
+          {short_name: "physimess", project: "physimess-sample", name: "PhysiMeSS", binary: "project", extra_run: ""},
+          {short_name: "interaction", project: "interaction-sample", name: "PhysiCell Interaction", binary: "interaction_demo", extra_run: ""},
+        ]
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Build ${{ matrix.projects.name }}
+      run: |
+        make ${{ matrix.projects.project }}
+        make clean
+        ${{ matrix.projects.extra_run }}
+        make static STATIC_OPENMP=/usr/lib/gcc/x86_64-linux-gnu/11/libgomp.a
+      
+    - name: Checking binary for ${{ matrix.projects.name }}
+      run: |
+        ldd ${{ matrix.projects.binary }}
+            
+    - name: Build ${{ matrix.projects.name }} project archive
+      run: |
+        rm -fr config/PhysiCell_settings-backup.xml
+        tar -zcvf ${{ matrix.projects.short_name }}-linux.tar.gz ${{ matrix.projects.binary }} Makefile main.cpp config/ custom_modules/
+         
+    - uses: actions/upload-release-asset@v1
+      if: github.event_name == 'release'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_name: ${{ matrix.projects.short_name }}-linux.tar.gz
+        asset_path: ${{ github.workspace }}/${{ matrix.projects.short_name }}.tar.gz
+        asset_content_type: application/gzip   
+        
+        
+  windows:
+    strategy:
+      matrix:
+        projects: [
+          {short_name: "physiboss-tutorial", project: "physiboss-tutorial", name: "PhysiBoSS tutorial", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-tutorial-invasion", project: "physiboss-tutorial-invasion", name: "PhysiBoSS Cancer Invasion", binary: "invasion_model", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-cell-lines", project: "physiboss-cell-lines-sample", name: "PhysiBoSS Cell Lines", binary: "PhysiBoSS_Cell_Lines", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template_BM", project: "template_BM", name: "PhysiBoSS Template", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template", project: "template", name: "PhysiCell Template", binary: "project", extra_run: ""},
+          {short_name: "rules", project: "rules-sample", name: "PhysiCell Rules", binary: "project", extra_run: ""},
+          {short_name: "physimess", project: "physimess-sample", name: "PhysiMeSS", binary: "project", extra_run: ""},
+          {short_name: "interaction", project: "interaction-sample", name: "PhysiCell Interaction", binary: "interaction_demo", extra_run: ""},
+        ]
+    
+    runs-on: windows-latest
+    
+    defaults:
+      run:
+        shell: msys2 {0}
+        
+    steps:
+    - uses: actions/checkout@v4
+    
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: mingw-w64-x86_64-binutils mingw-w64-x86_64-gcc mingw-w64-x86_64-headers-git mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-lapack mingw-w64-x86_64-openblas mingw-w64-x86_64-libxml2 mingw-w64-x86_64-bzip2 mingw-w64-x86_64-python mingw-w64-x86_64-python-zstandard mingw-w64-x86_64-python-cffi make bison flex mingw-w64-x86_64-ca-certificates
+
+    - name: Build ${{ matrix.projects.name }} project
+      run: |
+        make ${{ matrix.projects.project }}
+        make clean
+        python beta/setup_windows_dep.py
+        ${{ matrix.projects.extra_run }}
+        make static
+        
+    - name: Checking binary for ${{ matrix.projects.name }}
+      run: |
+        ldd .\\${{ matrix.projects.binary }}.exe
+      
+    - name: Build ${{ matrix.projects.name }} project archive
+      run: |
+        rm -fr config/PhysiCell_settings-backup.xml
+        tar -zcvf ${{ matrix.projects.short_name }}-win.tar.gz ${{ matrix.projects.binary }}.exe *.dll Makefile main.cpp config/ custom_modules/
+        
+    - uses: actions/upload-release-asset@v1
+      if: github.event_name == 'release'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_name: ${{ matrix.projects.short_name }}-win.tar.gz
+        asset_path: ${{ github.workspace }}\${{ matrix.projects.short_name }}-win.tar.gz
+        asset_content_type: application/gzip
+        
+  
+  macos_step0a:
+    strategy:
+      matrix:
+        projects: [
+          {short_name: "physiboss-tutorial", project: "physiboss-tutorial", name: "PhysiBoSS tutorial", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-tutorial-invasion", project: "physiboss-tutorial-invasion", name: "PhysiBoSS Cancer Invasion", binary: "invasion_model", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-cell-lines", project: "physiboss-cell-lines-sample", name: "PhysiBoSS Cell Lines", binary: "PhysiBoSS_Cell_Lines", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template_BM", project: "template_BM", name: "PhysiBoSS Template", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template", project: "template", name: "PhysiCell Template", binary: "project", extra_run: ""},
+          {short_name: "rules", project: "rules-sample", name: "PhysiCell Rules", binary: "project", extra_run: ""},
+          {short_name: "physimess", project: "physimess-sample", name: "PhysiMeSS", binary: "project", extra_run: ""},
+          {short_name: "interaction", project: "interaction-sample", name: "PhysiCell Interaction", binary: "interaction_demo", extra_run: ""},
+       ]
+    
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run : brew install gcc@11
+      
+    - name: Build ${{ matrix.projects.name }} project
+      run: |
+        export MACOSX_DEPLOYMENT_TARGET=12
+        make ${{ matrix.projects.project }}
+        make clean
+        ${{ matrix.projects.extra_run }}
+        make PHYSICELL_CPP=g++-11 static
+        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos12
+
+    - name: Caching produced project binary 
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos12
+        key: ${{ runner.os }}-macos12-${{ github.run_id }}
+    
+    - name: Look at the generated binary
+      run: |
+        otool -L ${{ matrix.projects.binary }}
+        otool -l ${{ matrix.projects.binary }}
+        lipo -archs ${{ matrix.projects.binary }}
+    
+  macos_step0b:
+    strategy:
+      matrix:
+        projects: [
+          {short_name: "physiboss-tutorial", project: "physiboss-tutorial", name: "PhysiBoSS tutorial", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-tutorial-invasion", project: "physiboss-tutorial-invasion", name: "PhysiBoSS Cancer Invasion", binary: "invasion_model", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-cell-lines", project: "physiboss-cell-lines-sample", name: "PhysiBoSS Cell Lines", binary: "PhysiBoSS_Cell_Lines", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template_BM", project: "template_BM", name: "PhysiBoSS Template", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template", project: "template", name: "PhysiCell Template", binary: "project", extra_run: ""},
+          {short_name: "rules", project: "rules-sample", name: "PhysiCell Rules", binary: "project", extra_run: ""},
+          {short_name: "physimess", project: "physimess-sample", name: "PhysiMeSS", binary: "project", extra_run: ""},
+          {short_name: "interaction", project: "interaction-sample", name: "PhysiCell Interaction", binary: "interaction_demo", extra_run: ""},
+        ]
+    
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Downgrade XCODE to 14.3.1
+      run: sudo xcode-select -switch /Applications/Xcode_14.3.1.app   
+      
+    - name: Install dependencies
+      run : brew install gcc@11
+      
+    - name: Build ${{ matrix.projects.name }} project
+      run: |
+        export MACOSX_DEPLOYMENT_TARGET=12
+        make ${{ matrix.projects.project }}
+        make clean
+        ${{ matrix.projects.extra_run }}
+        make PHYSICELL_CPP=g++-11 static
+        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macosm1
+   
+    - name: Caching produced project binary 
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macosm1
+        key: ${{ runner.os }}-macosm1-${{ github.run_id }}
+      
+    - name: Look at the generated binary
+      run: |
+        otool -L ${{ matrix.projects.binary }}
+        otool -l ${{ matrix.projects.binary }}
+        lipo -archs ${{ matrix.projects.binary }} 
+        
+  macos_step1:
+    strategy:
+      matrix:
+        projects: [
+          {short_name: "physiboss-tutorial", project: "physiboss-tutorial", name: "PhysiBoSS tutorial", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-tutorial-invasion", project: "physiboss-tutorial-invasion", name: "PhysiBoSS Cancer Invasion", binary: "invasion_model", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "physiboss-cell-lines", project: "physiboss-cell-lines-sample", name: "PhysiBoSS Cell Lines", binary: "PhysiBoSS_Cell_Lines", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template_BM", project: "template_BM", name: "PhysiBoSS Template", binary: "project", extra_run: "make Compile_MaBoSS PHYSICELL_CPP=g++-11"},
+          {short_name: "template", project: "template", name: "PhysiCell Template", binary: "project", extra_run: ""},
+          {short_name: "rules", project: "rules-sample", name: "PhysiCell Rules", binary: "project", extra_run: ""},
+          {short_name: "physimess", project: "physimess-sample", name: "PhysiMeSS", binary: "project", extra_run: ""},
+          {short_name: "interaction", project: "interaction-sample", name: "PhysiCell Interaction", binary: "interaction_demo", extra_run: ""},
+        ]
+        
+    runs-on: macos-12
+    needs: [macos_step0a, macos_step0b]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Caching produced project binary 
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macosm1
+        key: ${{ runner.os }}-macosm1-${{ github.run_id }}
+    
+    - name: Caching produced project binary 
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos12
+        key: ${{ runner.os }}-macos12-${{ github.run_id }}
+    
+    - name: Creating universal binary
+      run: | 
+        lipo -create -output ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos12 ${{ matrix.projects.binary }}_macosm1
+
+    - name: Checking universal binary
+      run: |
+        lipo -archs ${{ matrix.projects.binary }}
+        otool -l ${{ matrix.projects.binary }}
+        otool -L ${{ matrix.projects.binary }}
+        
+    - name: Build project archive
+      run: |
+        make ${{ matrix.projects.project }}
+        rm -fr config/PhysiCell_settings-backup.xml
+        tar -zcvf ${{ matrix.projects.short_name }}-macos.tar.gz ${{ matrix.projects.binary }} Makefile main.cpp config/ custom_modules/
+        
+    - uses: actions/upload-release-asset@v1
+      if: github.event_name == 'release'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_name: ${{ matrix.projects.short_name }}-macos.tar.gz
+        asset_path: ${{ github.workspace }}/${{ matrix.projects.short_name }}-macos.tar.gz
+        asset_content_type: application/gzip

--- a/beta/download_binary.py
+++ b/beta/download_binary.py
@@ -1,0 +1,111 @@
+# This script attempts to download the MaBoSS (binary) library(s) and
+# headers for your particular operating system. It installs them in a standard
+# location (relative to a PhysiCell installation) which will be used by a PhysiCell Makefile.
+#
+# Authors: Randy Heiland, Vincent Noel
+
+import platform
+import urllib.request
+import os
+import sys
+import tarfile
+import stat
+import shutil
+
+physicell_version = "1.14.0"
+repo_physicell = "MathCancer/PhysiCell"
+physiboss_version = "v2.2.3"
+repo_physiboss = "sysbio-curie/PhysiBoSS"
+list_models = {
+    "physiboss-tutorial": "https://github.com/" + repo_physiboss + "/releases/download/" + physiboss_version + "/", 
+    "physiboss-tutorial-invasion": "https://github.com/" + repo_physiboss + "/releases/download/" + physiboss_version + "/", 
+    "physiboss-cell-lines": "https://github.com/" + repo_physiboss + "/releases/download/" + physiboss_version + "/",   
+    "template_BM": "https://github.com/" + repo_physiboss + "/releases/download/" + physiboss_version + "/", 
+    "template": "https://github.com/" + repo_physicell + "/releases/download/" + physicell_version + "/", 
+    "rules": "https://github.com/" + repo_physicell + "/releases/download/" + physicell_version + "/", 
+    "physimess": "https://github.com/" + repo_physicell + "/releases/download/" + physicell_version + "/", 
+    "interaction": "https://github.com/" + repo_physicell + "/releases/download/" + physicell_version + "/", 
+}
+
+def print_usage():
+     print("Usage : python download_binary.py <model>")
+     print("")
+     print("Models available : %s" % (",".join(list_models.keys())))
+
+if len(sys.argv) < 2:
+     print_usage()
+     exit(1)
+     
+model = sys.argv[1]
+     
+if model in ["-h", "--help"] or model not in list_models.keys():
+     print_usage()
+     exit(1)
+
+print('> Chosen model: ', model)
+
+os_type = platform.system()
+print('> Operating system: ', os_type)
+     
+mb_file = ""
+if os_type.lower() == 'darwin':
+    mb_file = model + "-macos.tar.gz"
+elif os_type.lower().startswith("win") or os_type.lower().startswith("msys_nt") or os_type.lower().startswith("mingw64_nt"):
+    mb_file = model + "-win.tar.gz"
+elif os_type.lower().startswith("linux"):
+    mb_file = model + "-linux.tar.gz"
+else:
+    print("Your operating system seems to be unsupported. Please create an new issue at https://github.com/PhysiBoSS/PhysiBoSS/issues/ ")
+    sys.exit(1)
+
+url = list_models[model] + mb_file
+print('> Downloading from: ', url)
+
+dir_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+print('> Loading into directory: ', dir_name)
+
+my_file = os.path.join(dir_name, mb_file)
+print('> File: ',my_file)
+
+def download_cb(blocknum, blocksize, totalsize):
+    readsofar = blocknum * blocksize
+    if totalsize > 0:
+        percent = readsofar * 1e2 / totalsize
+        s = "\r%5.1f%% %*d / %d" % (
+            percent, len(str(totalsize)), readsofar, totalsize)
+        sys.stderr.write(s)
+        if readsofar >= totalsize: # near the end
+            sys.stderr.write("\n")
+    else: # total size is unknown
+        sys.stderr.write("read %d\n" % (readsofar,))
+
+urllib.request.urlretrieve(url, my_file, download_cb)
+
+print('> Creating backup of XML settings, Makefile, main.cpp')
+if os.path.exists("Makefile"):
+    shutil.copyfile("Makefile", "Makefile-backup")
+if os.path.exists("main.cpp"):
+    shutil.copyfile("main.cpp", "main-backup.cpp")
+if os.path.exists(os.path.join("config", "PhysiCell_settings.xml")):
+    shutil.copyfile(os.path.join("config", "PhysiCell_settings.xml"), os.path.join("PhysiCell_settings-backup.xml"))
+    
+os.chdir(dir_name)
+print('> Uncompressing the model')
+
+try:
+    tar = tarfile.open(mb_file)
+    tar.extractall()
+    binary_name = [names for names in tar.getnames() if not names.endswith(".dll")][0]
+    tar.close()
+    os.remove(mb_file)
+
+except:
+    print('! Error untarring the file')
+    exit(1)
+
+new_name = "project" if not mb_file.endswith("win.tar.gz") else "project.exe"
+os.rename(binary_name, new_name)
+st = os.stat(new_name)
+os.chmod(new_name, st.st_mode | stat.S_IEXEC)
+
+print('> Done. You can now run %s\n' % new_name)

--- a/beta/setup_windows_dep.py
+++ b/beta/setup_windows_dep.py
@@ -1,0 +1,63 @@
+# This script attempts to download the windows mingw64 libraries which cannot be statically 
+# included in the binary, and puts them in the root folder of PhysiCell
+#
+# Authors: Vincent Noel
+
+import urllib.request
+import os
+import sys
+import tarfile
+from pathlib import Path
+import tempfile
+import zstandard  
+import shutil
+
+if zstandard is None:
+            raise ImportError("pip install zstandard")
+
+libs = {
+    "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-13.2.0-3-any.pkg.tar.zst": [
+        "mingw64/bin/libgcc_s_seh-1.dll", "mingw64/bin/libgomp-1.dll"
+    ],
+    "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-libwinpthread-git-11.0.0.r551.g86a5e0f41-1-any.pkg.tar.zst": [
+        "mingw64/bin/libwinpthread-1.dll"
+    ]
+}
+
+for url, files in libs.items():
+
+    fname = url.split("/")[-1]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+
+        def download_cb(blocknum, blocksize, totalsize):
+            readsofar = blocknum * blocksize
+            if totalsize > 0:
+                percent = readsofar * 1e2 / totalsize
+                s = "\r%5.1f%% %*d / %d" % (
+                    percent, len(str(totalsize)), readsofar, totalsize)
+                sys.stderr.write(s)
+                if readsofar >= totalsize: # near the end
+                    sys.stderr.write("\n")
+            else: # total size is unknown
+                sys.stderr.write("read %d\n" % (readsofar,))
+        
+        urllib.request.urlretrieve(url, os.path.join(temp_dir, fname), download_cb)
+            
+        
+        archive = Path(os.path.join(temp_dir, fname))
+        out_path = Path(temp_dir)
+
+        dctx = zstandard.ZstdDecompressor()
+
+        with tempfile.TemporaryFile(suffix=".tar") as ofh:
+            with archive.open("rb") as ifh:
+                dctx.copy_stream(ifh, ofh)
+            ofh.seek(0)
+            with tarfile.open(fileobj=ofh) as z:
+                z.extractall(out_path)
+    
+        for file_path in files:
+            shutil.copyfile(os.path.join(out_path, file_path), os.path.join(os.getcwd(), file_path.split("/")[-1]))
+
+print('Done.\n')

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -11,6 +11,10 @@ ifdef PHYSICELL_CPP
 	CC := $(PHYSICELL_CPP)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -44,7 +48,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -70,6 +76,9 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiCell_custom_module_OBJECTS)
 all: main.cpp $(ALL_OBJECTS)
 	$(COMPILE_COMMAND) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp 
 	make name
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -11,6 +11,10 @@ ifdef PHYSICELL_CPP
 	CC := $(PHYSICELL_CPP)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -44,7 +48,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -72,6 +78,9 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiMeSS_OBJECTS) $(PhysiCell_custom_modu
 all: main.cpp $(ALL_OBJECTS)
 	$(COMPILE_COMMAND) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp 
 	make name
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -11,6 +11,10 @@ ifdef PHYSICELL_CPP
 	CC := $(PHYSICELL_CPP)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -44,7 +48,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -70,6 +76,9 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiCell_custom_module_OBJECTS)
 all: main.cpp $(ALL_OBJECTS)
 	$(COMPILE_COMMAND) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp 
 	make name
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -11,6 +11,10 @@ ifdef PHYSICELL_CPP
 	CC := $(PHYSICELL_CPP)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -44,7 +48,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -70,6 +76,9 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiCell_custom_module_OBJECTS)
 all: main.cpp $(ALL_OBJECTS)
 	$(COMPILE_COMMAND) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp 
 	make name
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -35,6 +35,10 @@ ifeq ($(shell expr $(MABOSS_MAX_NODES) '>' 64), 1)
 LIB := -L$(CUR_DIR)/$(MABOSS_DIR)/lib -lMaBoSS_$(MABOSS_MAX_NODES)n-static $(LDL_FLAG)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -70,7 +74,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -101,6 +107,9 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiCell_custom_module_OBJECTS) $(PhysiBo
 all: main.cpp $(ALL_OBJECTS) $(MaBoSS)
 	$(COMPILE_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB)
 	make name
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -35,6 +35,10 @@ ifeq ($(shell expr $(MABOSS_MAX_NODES) '>' 64), 1)
 LIB := -L$(CUR_DIR)/$(MABOSS_DIR)/lib -lMaBoSS_$(MABOSS_MAX_NODES)n-static $(LDL_FLAG)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -68,7 +72,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -95,8 +101,11 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiCell_custom_module_OBJECTS) $(PhysiBo
 # compile the project 
 
 all: main.cpp $(ALL_OBJECTS) $(MaBoSS)
-	$(COMPILE_COMMAND) $(INC)  -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB)
+	$(COMPILE_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB)
 	make name
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -35,6 +35,10 @@ ifeq ($(shell expr $(MABOSS_MAX_NODES) '>' 64), 1)
 LIB := -L$(CUR_DIR)/$(MABOSS_DIR)/lib -lMaBoSS_$(MABOSS_MAX_NODES)n-static $(LDL_FLAG)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -68,7 +72,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -97,6 +103,9 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiCell_custom_module_OBJECTS) $(PhysiBo
 all: main.cpp $(ALL_OBJECTS) $(MaBoSS)
 	$(COMPILE_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB)
 	make name 
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -35,6 +35,10 @@ ifeq ($(shell expr $(MABOSS_MAX_NODES) '>' 64), 1)
 LIB := -L$(CUR_DIR)/$(MABOSS_DIR)/lib -lMaBoSS_$(MABOSS_MAX_NODES)n-static $(LDL_FLAG)
 endif
 
+ifndef STATIC_OPENMP
+	STATIC_OPENMP = -fopenmp
+endif
+
 ARCH := native # best auto-tuning
 # ARCH := core2 # a reasonably safe default for most CPUs since 2007
 # ARCH := corei7
@@ -70,7 +74,9 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -101,6 +107,9 @@ ALL_OBJECTS := $(PhysiCell_OBJECTS) $(PhysiCell_custom_module_OBJECTS) $(PhysiBo
 all: main.cpp $(ALL_OBJECTS) $(MaBoSS)
 	$(COMPILE_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB)
 	make name
+
+static: main.cpp $(ALL_OBJECTS) $(MaBoSS)
+	$(LINK_COMMAND) $(INC) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp $(LIB) -static-libgcc -static-libstdc++ $(STATIC_OPENMP)
 
 name:
 	@echo ""


### PR DESCRIPTION
This is still very preliminary, but I thought I would send a PR to start discussing it. 

I tried to find a way for users to avoid compilation, and to simply download binaries for a (small) list of projects.  The biggest use case are the template models : That way people can use them and simply use PhysiCell Studio to build their model. 
The binaries are build by GitHub actions, and are stored as release assets for each release. Then for users, they just need to run a python script, which will basically do the equivalent of make <project>; make. Meaning that the binary is ready, the config files are there, and if they want to add custom modules and recompile, it works. This script could later be integrated into PhysiCell Studio.
 
A few remarks about each OS : 

- On linux, it's relatively easy. The Makefile has to be modified to have static libopenmp, but nothing too ugly. 

- On macos, I'm building universal binaries (amd64 and arm64 compatible). One annoying issue here is that by default, macos will block downloaded binaries, so you have to allow them in the privacy and security settings. Also, sometimes the build fails, like 1/4 of the time. Not sure why yet, but just relaunching the job fixes it. On some machines (well, actually just one I know of), the binary runs via bash, but not via PhysiCell studio. And compiling works. 

- On windows, there are three dlls that I couldn't include in the binary, but that can be put in the same folder as the binary and it works. So I added a script to download these dlls. Not sure exactly how it works for license, but we are not providing PhysiCell with them, we just provide a way for the user to download them when needed. I probably should add their license somewhere in this case. Please don't sue me.

I'm including an example here with PhysiBoSS cell lines sample project, but I can quickly add another example if needed. 

What do you think ?