### PR TITLE
getter functions for lists of dying and dividing cells

### DIFF
--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -370,6 +370,20 @@ bool Cell_Container::contain_any_cell(int voxel_index)
 	return agent_grid[voxel_index].size()==0?false:true;
 }
 
+const std::vector<Cell*>& Cell_Container::get_dividing_cells_in_container(){
+  return this-> cells_ready_to_divide;
+}
+const std::vector<Cell*>& Cell_Container::get_dying_cells_in_container(){
+  return this-> cells_ready_to_die;
+}
+const std::vector<Cell*>& Cell_Container::get_all_dividing(){
+  return (((Cell_Container *)microenvironment.agent_container)->get_dividing_cells_in_container());
+}
+const std::vector<Cell*>& Cell_Container::get_all_dying(){
+  return (((Cell_Container *)microenvironment.agent_container)->get_dying_cells_in_container());
+}
+
+
 int find_escaping_face_index(Cell* agent)
 {
 	if(agent->position[0] <= agent->get_container()->underlying_mesh.bounding_box[PhysiCell_constants::mesh_min_x_index])

--- a/core/PhysiCell_cell_container.h
+++ b/core/PhysiCell_cell_container.h
@@ -115,6 +115,12 @@ class Cell_Container : public BioFVM::Agent_Container
 	void flag_cell_for_division( Cell* pCell ); 
 	void flag_cell_for_removal( Cell* pCell ); 
 	bool contain_any_cell(int voxel_index);
+
+  const std::vector<Cell*> &get_dividing_cells_in_container();
+  const std::vector<Cell*> &get_dying_cells_in_container();
+
+  const std::vector<Cell*> &get_all_dividing();
+  const std::vector<Cell*> &get_all_dying();
 };
 
 int find_escaping_face_index(Cell* agent);


### PR DESCRIPTION
I realize there are other ways to figure this out, but it might be very convenient to access the list of cells that are going to divide or die in C++ code. These are (I think) relatively safe getters that pass back a reference to the cell_containers private members:
cells_ready_to_divide and cells_ready_to_die, I realize these getters have some redundancy, but I wasn't sure which version would be the preferred. My main motivation is that these functions allow me to easily check the safety of cell addons that aren't inheriting the Cell class. It also makes it easier to code custom functions that track generations or customize post-death cell actions outside of using a "phenotype" approach.  