### PR TITLE
Actually use value of legacy_cell_defaults_copy

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1950,7 +1950,7 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 		pugi::xml_node node_options = xml_find_node( physicell_config_root , "options" ); 
 		bool disable_bugfix = false; 
 		if( node_options )
-		{ xml_get_bool_value( node_options, "legacy_cell_defaults_copy" ); }
+		{ disable_bugfix = xml_get_bool_value( node_options, "legacy_cell_defaults_copy" ); }
 
 		if( disable_bugfix == false )
 		{


### PR DESCRIPTION
disable_bugfix did not update based on the value of legacy_cell_defaults_copy previously. This fixes that for anyone still using the old, buggy version.