### PR TITLE
changes to Makefile-default to allow user project custom_modules with a folder structure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -464,14 +464,14 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
 	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:

--- a/Makefile
+++ b/Makefile
@@ -465,14 +465,14 @@ save:
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
 	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -464,14 +464,14 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
 	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -465,14 +465,14 @@ save:
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
 	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "


### PR DESCRIPTION
To be able to pack my current projects as users projects, I would appreciate it if custom modules could have a folder structure. This small change to the Makefile-default would enable that. 
Thank you! Elmar