### PR TITLE
enable the random_seed integer parameter to be set for random behavior too.

### DIFF
--- a/sample_projects/template/custom_modules/custom.cpp
+++ b/sample_projects/template/custom_modules/custom.cpp
@@ -69,9 +69,13 @@
 
 void create_cell_types( void )
 {
-	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
-	
+	// set the random seed
+	if ( parameters.ints("random_seed") < 0 ) {
+		SeedRandom(); // random
+	} else {
+		SeedRandom( parameters.ints("random_seed") ); // seeded
+	}
+
 	/* 
 	   Put any modifications to default cell definition here if you 
 	   want to have "inherited" by other cell types. 


### PR DESCRIPTION
Currently, negative parameters.ints("random_seed") will cause the Mersenne Twister to be seeded with seed zero. 
There is no way to "seed" for random behavior.
For that reason, I saw code which randomly choosing an integer in a Python script to set the random_seed in the config/PhysiCell_settings.xml.
If my understanding how random code generators work is correct, then this approach is biased!
This is because the Mersenne Twister has 2^19937 - 1 states. Int64 however, has only 2^64 different states. Briefly, with this approach, these people miss out on most of the possible starting states.
There has to be an easy way set for random behavior!

With this small change in the template project, negative random seeds will result in random behavior, while zero and positive seeds will truly seed the random number generator, as we know it from the past.
This will be the case for any future projects, based on this template project.
For zero and positive numbers, nothing changes. We will not break with the past. But we open up a simple way to make random "seeding" for the runs possible for anyone, even directly in the Studio GUI, without having to make code changes in C++ in the custom.cpp.