### PR TITLE
Unnecessary warning message to "exit cycle phase 2 or 3" behaviors

### DIFF
--- a/core/PhysiCell_signal_behavior.cpp
+++ b/core/PhysiCell_signal_behavior.cpp
@@ -1260,7 +1260,7 @@ void set_single_behavior( Cell* pCell, int index , double parameter )
 
 	// cycle entry (exit from phase 0) and exit from up to 5 more phases 
 	static int first_cycle_index = find_behavior_index("exit from cycle phase 0" ); //  4*m; 
-	if( index >= first_cycle_index && index < first_cycle_index+6 )
+	if( index >= first_cycle_index && index < first_cycle_index+6 && !pCell->phenotype.death.dead )
 	{
 		int max_cycle_index = pCell->phenotype.cycle.model().phases.size(); 
 		if( index < first_cycle_index + max_cycle_index )


### PR DESCRIPTION
Add a test for dead cells in the `set_single_behavior` function. This test avoids warning messages when using behaviors to exit cell cycle phases 2 or 3 in rules. Generally, this does not impact other function calls, as we do not need to change the cell cycle rates for dead cells. Note that even when using a rule not applicable to dead cells, the behavior values revert to their prior state (lines [372](https://github.com/MathCancer/PhysiCell/blob/84d033adba4a013f1fb3e7b7ece252ee254a1f26/core/PhysiCell_rules.cpp#L372) and [386](https://github.com/MathCancer/PhysiCell/blob/84d033adba4a013f1fb3e7b7ece252ee254a1f26/core/PhysiCell_rules.cpp#L386) in `PhysiCell_rules.cpp`) 