### PR TITLE
Fix elapsed time check to see if cell cycle need to transition

### DIFF
--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -302,7 +302,7 @@ void Cycle_Model::advance_model( Cell* pCell, Phenotype& phenotype, double dt )
 			bool continue_transition = false; 
 			if( phase_links[i][k].fixed_duration )
 			{
-				if( phenotype.cycle.data.elapsed_time_in_phase >= ((1.0/phenotype.cycle.data.transition_rates[i][k]) - 0.5 * dt) )
+				if( phenotype.cycle.data.elapsed_time_in_phase > ((1.0/phenotype.cycle.data.transition_rates[i][k]) - 0.5 * dt) )
 				{
 					continue_transition = true; 
 				}

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -302,7 +302,7 @@ void Cycle_Model::advance_model( Cell* pCell, Phenotype& phenotype, double dt )
 			bool continue_transition = false; 
 			if( phase_links[i][k].fixed_duration )
 			{
-				if( fabs(phenotype.cycle.data.elapsed_time_in_phase - (1.0/phenotype.cycle.data.transition_rates[i][k])) < 0.01 * dt )
+				if( phenotype.cycle.data.elapsed_time_in_phase >= ((1.0/phenotype.cycle.data.transition_rates[i][k]) - 0.5 * dt) )
 				{
 					continue_transition = true; 
 				}

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -302,7 +302,7 @@ void Cycle_Model::advance_model( Cell* pCell, Phenotype& phenotype, double dt )
 			bool continue_transition = false; 
 			if( phase_links[i][k].fixed_duration )
 			{
-				if( phenotype.cycle.data.elapsed_time_in_phase > 1.0/phenotype.cycle.data.transition_rates[i][k] )
+				if( fabs(phenotype.cycle.data.elapsed_time_in_phase - (1.0/phenotype.cycle.data.transition_rates[i][k])) < 0.01 * dt )
 				{
 					continue_transition = true; 
 				}


### PR DESCRIPTION
Working with Arnau on the cell cycle unit test of the multiscale benchmark, we realized that PhysiCell would sometimes have longer cell cycle phases than defined. I tracked it up to this comparison, and I changed it to comparing the absolute value of the difference of the two values to a small number.