### PR TITLE
allow user to change max num (spring) attachments in xml

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -2582,6 +2582,10 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 		if( node_mech )
 		{ pM->detachment_rate = xml_get_my_double_value( node_mech ); }	
 
+		node_mech = node.child( "maximum_number_of_attachments" );
+		if ( node_mech )
+		{ pM->maximum_number_of_attachments = xml_get_my_int_value( node_mech ); }
+
 	}
 	
 	// motility 

--- a/sample_projects/template/config/PhysiCell_settings.xml
+++ b/sample_projects/template/config/PhysiCell_settings.xml
@@ -266,6 +266,7 @@
                     <attachment_elastic_constant type="double" units="1/min">0.01</attachment_elastic_constant> 
                     <attachment_rate type="double" units="1/min">0.0</attachment_rate> 
                     <detachment_rate type="double" units="1/min">0.0</detachment_rate> 
+					<maximum_number_of_attachments>12</maximum_number_of_attachments>
 				</mechanics>
 				
 				<motility>  


### PR DESCRIPTION
allow for new element at end of `<mechanics>` element that can set the maximum number of attachments. Max num attachments is already a behavior so this is already hooked into the rules grammar.

Minimal working element:
```
<mechanics> 
	...
	<attachment_rate type="double" units="1/min">0.0</attachment_rate> 
	<detachment_rate type="double" units="1/min">0.0</detachment_rate> 
	<maximum_number_of_attachments>12</maximum_number_of_attachments>
</mechanics>
```