### PR TITLE
Github action to build and run template project on all 3 OS and make output folder

### DIFF
--- a/.github/workflows/test-macosx.yml
+++ b/.github/workflows/test-macosx.yml
@@ -67,3 +67,22 @@ jobs:
         ./project config/Fibre_Initialisation/mymodel_initialisation.xml
         ./project config/Cell_Fibre_Mechanics/mymodel_rotating.xml
         
+  build_template:
+
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run : brew install gcc@11
+      
+    - name: Build template project
+      run: |
+        make template
+        make clean
+        make PHYSICELL_CPP=g++-11
+        
+    - name: Run template project
+      run: |
+        ./project config/PhysiCell_settings.xml

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -47,4 +47,23 @@ jobs:
         ./project
         ./project config/Fibre_Initialisation/mymodel_initialisation.xml
         ./project config/Cell_Fibre_Mechanics/mymodel_rotating.xml
+
+  build_template:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Install dependencies
+      run: sudo apt-get install flex bison
+      
+    - name: Build template project
+      run: |
+        make template
+        make clean
+        make
+        
+    - name: Run template project
+      run: |
+        ./project config/PhysiCell_settings.xml
         

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -53,4 +53,28 @@ jobs:
         .\\project
         .\\project config\\Fibre_Initialisation\\mymodel_initialisation.xml
         .\\project config\\Cell_Fibre_Mechanics\\mymodel_rotating.xml
+
+  build_template:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
         
+    steps:
+    - uses: actions/checkout@v2
+    
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: base-devel flex bison gcc make diffutils mingw-w64-x86_64-toolchain mingw-w64-x86_64-ca-certificates
+    
+    - name: Build template project
+      run: |
+        make template
+        make clean
+        make
+
+    - name: Run template project
+      run: |
+        .\\project.exe config\\PhysiCell_settings.xml

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -300,14 +300,38 @@ void PhysiCell_Settings::read_from_pugixml( void )
 	return; 
 }
 
-void create_output_directory(std::string folder)
+bool create_directories(const std::string &path)
 {
-	// if the directory doesn't exist, create it
+	std::vector<std::string> directories;
+	size_t pos = 0;
+    std::string currentPath;
+
+    while ((pos = path.find_first_of("/\\", pos)) != std::string::npos) {
+        currentPath = path.substr(0, pos++);
+        if (!create_directory(currentPath)) {
+            return false;
+        }
+    }
+    return create_directory(path);
+}
+
+bool create_directory(const std::string &path)
+{
 #if defined(__MINGW32__) || defined(__MINGW64__)
-	mkdir(folder.c_str());
+	bool success = mkdir(path.c_str()) == 0;
 #else
-	mkdir(folder.c_str(), 0755);
+	bool success = mkdir(path.c_str(), 0755) == 0;
 #endif
+	return success || errno == EEXIST;
+}
+
+void create_output_directory(const std::string& path)
+{
+	if (!create_directories(path))
+	{
+		std::cout << "ERROR: Could not create output directory " << path << " ! Quitting." << std::endl;
+		exit(-1);
+	}
 }
 
 void create_output_directory(void)

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -64,7 +64,8 @@
 #                                                                             #
 ###############################################################################
 */
- 
+
+#include <sys/stat.h>
 #include "./PhysiCell_settings.h"
 
 using namespace BioFVM; 
@@ -297,6 +298,21 @@ void PhysiCell_Settings::read_from_pugixml( void )
 	// random seed options 
 	
 	return; 
+}
+
+void create_output_directory(std::string folder)
+{
+	// if the directory doesn't exist, create it
+#if defined(__MINGW32__) || defined(__MINGW64__)
+	mkdir(folder.c_str());
+#else
+	mkdir(folder.c_str(), 0755);
+#endif
+}
+
+void create_output_directory(void)
+{
+	create_output_directory(PhysiCell_settings.folder);
 }
 
 PhysiCell_Globals PhysiCell_globals; 

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -137,7 +137,10 @@ class PhysiCell_Settings
 	void read_from_pugixml( void ); 
 };
 
-void create_output_directory(std::string folder);
+bool create_directories(const std::string &path);
+bool create_directory(const std::string &path);
+
+void create_output_directory(const std::string& path);
 void create_output_directory(void);
 
 class PhysiCell_Globals

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -137,6 +137,9 @@ class PhysiCell_Settings
 	void read_from_pugixml( void ); 
 };
 
+void create_output_directory(std::string folder);
+void create_output_directory(void);
+
 class PhysiCell_Globals
 {
  private:

--- a/sample_projects/template/config/PhysiCell_settings.xml
+++ b/sample_projects/template/config/PhysiCell_settings.xml
@@ -87,7 +87,7 @@
 	</domain>
 	
 	<overall>
-		<max_time units="min">7200</max_time> <!-- 5 days * 24 h * 60 min -->
+		<max_time units="min">60</max_time> <!-- 5 days * 24 h * 60 min -->
 		<time_units>min</time_units>
 		<space_units>micron</space_units>
 	
@@ -101,7 +101,7 @@
 	</parallel> 
 	
 	<save>
-		<folder>output</folder> <!-- use . for root --> 
+		<folder>output/t1/t2/t3</folder> <!-- use . for root --> 
 
 		<full_data>
 			<interval units="min">60</interval>

--- a/sample_projects/template/main.cpp
+++ b/sample_projects/template/main.cpp
@@ -89,20 +89,20 @@ int main( int argc, char* argv[] )
 	
 	bool XML_status = false; 
 	char copy_command [1024]; 
+	std::string path_to_config_file = "./config/PhysiCell_settings.xml";
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		path_to_config_file = argv[1];
 	}
-	else
-	{
-		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
-	}
+	XML_status = load_PhysiCell_config_file( path_to_config_file );
 	if( !XML_status )
 	{ exit(-1); }
-	
+
+	// make sure the output folder exists
+	create_output_directory();
+
 	// copy config file to output directry 
+	sprintf(copy_command, "cp %s %s", path_to_config_file.c_str(), PhysiCell_settings.folder.c_str()); // get the copy command ready
 	system( copy_command ); 
 	
 	// OpenMP setup


### PR DESCRIPTION
This includes changes made in #241 (template project tests) and modifies the changes in #243 (make output folder). These are bundled together because of the intertwined history of those two PRs.

Unlike #243, this PR puts the output creation in `modules/PhysiCell_settings.cpp` to 
1. put it out of sight for most users since they won't need to do anything with it
2. make it accessible to others not using the template project `main.cpp`

I also went ahead and simplified the code around reading the path to the config file to reduce redundancy, improve readability, and enhance maintainability.