### PR TITLE
fix PhysiCell constants for more compilers

### DIFF
--- a/core/PhysiCell_constants.cpp
+++ b/core/PhysiCell_constants.cpp
@@ -76,12 +76,63 @@ double mechanics_dt = 0.1;
 double phenotype_dt = 6.0;
 double intracellular_dt = 0.01;
 
-std::unordered_map<std::string,int> cycle_model_codes = 
-{
-	{ "Ki67 (advanced)", PhysiCell_constants::advanced_Ki67_cycle_model}, 
-	{ "Ki67 (basic)" ,PhysiCell_constants::basic_Ki67_cycle_model},
-	{ "Flow cytometry model (basic)",PhysiCell_constants::flow_cytometry_cycle_model},
-	// { ,PhysiCell_constants::live_apoptotic_cycle_model}, // not implemented 
+
+// currently recognized cell cycle models 
+const int PhysiCell_constants::advanced_Ki67_cycle_model= 0;
+const int PhysiCell_constants::basic_Ki67_cycle_model=1;
+const int PhysiCell_constants::flow_cytometry_cycle_model=2;
+const int PhysiCell_constants::live_apoptotic_cycle_model=3;
+const int PhysiCell_constants::total_cells_cycle_model=4;
+const int PhysiCell_constants::live_cells_cycle_model = 5; 
+const int PhysiCell_constants::flow_cytometry_separated_cycle_model = 6; 
+const int PhysiCell_constants::cycling_quiescent_model = 7; 
+
+// currently recognized death models 
+const int PhysiCell_constants::apoptosis_death_model = 100; 
+const int PhysiCell_constants::necrosis_death_model = 101; 
+const int PhysiCell_constants::autophagy_death_model = 102; 
+
+const int PhysiCell_constants::custom_cycle_model=9999; 
+
+// currently recognized cell cycle and death phases 
+// cycle phases
+const int PhysiCell_constants::Ki67_positive_premitotic=0; 
+const int PhysiCell_constants::Ki67_positive_postmitotic=1; 
+const int PhysiCell_constants::Ki67_positive=2; 
+const int PhysiCell_constants::Ki67_negative=3; 
+const int PhysiCell_constants::G0G1_phase=4;
+const int PhysiCell_constants::G0_phase=5;
+const int PhysiCell_constants::G1_phase=6; 
+const int PhysiCell_constants::G1a_phase=7; 
+const int PhysiCell_constants::G1b_phase=8;
+const int PhysiCell_constants::G1c_phase=9;
+const int PhysiCell_constants::S_phase=10;
+const int PhysiCell_constants::G2M_phase=11;
+const int PhysiCell_constants::G2_phase=12;
+const int PhysiCell_constants::M_phase=13;
+const int PhysiCell_constants::live=14;
+
+const int PhysiCell_constants::G1pm_phase = 15;
+const int PhysiCell_constants::G1ps_phase = 16; 
+
+const int PhysiCell_constants::cycling = 17; 
+const int PhysiCell_constants::quiescent = 18; 
+
+
+const int PhysiCell_constants::custom_phase = 9999;
+// death phases
+const int PhysiCell_constants::apoptotic=100;
+const int PhysiCell_constants::necrotic_swelling=101;
+const int PhysiCell_constants::necrotic_lysed=102;
+const int PhysiCell_constants::necrotic=103; 
+const int PhysiCell_constants::debris=104; 
+
+std::unordered_map<std::string,int> cycle_model_codes = {
+
+    { "Ki67 (advanced)", PhysiCell_constants::advanced_Ki67_cycle_model}, 
+    { "Ki67 (basic)" ,PhysiCell_constants::basic_Ki67_cycle_model},
+    { "Flow cytometry model (basic)",PhysiCell_constants::flow_cytometry_cycle_model},
+// { ,PhysiCell_constants::live_apoptotic_cycle_model}, // not implemented 
 	// { ,PhysiCell_constants::total_cells_cycle_model}, // not implemented 
 	{ "Live",PhysiCell_constants::live_cells_cycle_model}, 
 	{ "Flow cytometry model (separated)",PhysiCell_constants::flow_cytometry_separated_cycle_model}, 

--- a/core/PhysiCell_constants.h
+++ b/core/PhysiCell_constants.h
@@ -102,54 +102,54 @@ class PhysiCell_constants
 	static const int mesh_uz_face_index=5;
 	
 	// currently recognized cell cycle models 
-	static const int advanced_Ki67_cycle_model= 0;
-	static const int basic_Ki67_cycle_model=1;
-	static const int flow_cytometry_cycle_model=2;
-	static const int live_apoptotic_cycle_model=3;
-	static const int total_cells_cycle_model=4;
-	static const int live_cells_cycle_model = 5; 
-	static const int flow_cytometry_separated_cycle_model = 6; 
-	static const int cycling_quiescent_model = 7; 
+	static const int advanced_Ki67_cycle_model;
+	static const int basic_Ki67_cycle_model;
+	static const int flow_cytometry_cycle_model;
+	static const int live_apoptotic_cycle_model;
+	static const int total_cells_cycle_model;
+	static const int live_cells_cycle_model ; 
+	static const int flow_cytometry_separated_cycle_model ; 
+	static const int cycling_quiescent_model ; 
 	
 	// currently recognized death models 
-	static const int apoptosis_death_model = 100; 
-	static const int necrosis_death_model = 101; 
-	static const int autophagy_death_model = 102; 
+	static const int apoptosis_death_model ; 
+	static const int necrosis_death_model ; 
+	static const int autophagy_death_model ; 
 	
-	static const int custom_cycle_model=9999; 
+	static const int custom_cycle_model; 
 	
 	// currently recognized cell cycle and death phases 
 	// cycle phases
-	static const int Ki67_positive_premitotic=0; 
-	static const int Ki67_positive_postmitotic=1; 
-	static const int Ki67_positive=2; 
-	static const int Ki67_negative=3; 
-	static const int G0G1_phase=4;
-	static const int G0_phase=5;
-	static const int G1_phase=6; 
-	static const int G1a_phase=7; 
-	static const int G1b_phase=8;
-	static const int G1c_phase=9;
-	static const int S_phase=10;
-	static const int G2M_phase=11;
-	static const int G2_phase=12;
-	static const int M_phase=13;
-	static const int live=14;
+	static const int Ki67_positive_premitotic; 
+	static const int Ki67_positive_postmitotic; 
+	static const int Ki67_positive; 
+	static const int Ki67_negative; 
+	static const int G0G1_phase;
+	static const int G0_phase;
+	static const int G1_phase; 
+	static const int G1a_phase; 
+	static const int G1b_phase;
+	static const int G1c_phase;
+	static const int S_phase;
+	static const int G2M_phase;
+	static const int G2_phase;
+	static const int M_phase;
+	static const int live;
 	
-	static const int G1pm_phase = 15;
-	static const int G1ps_phase = 16; 
+	static const int G1pm_phase ;
+	static const int G1ps_phase ; 
 	
-	static const int cycling = 17; 
-	static const int quiescent = 18; 
+	static const int cycling ; 
+	static const int quiescent ; 
 	
 	
-	static const int custom_phase = 9999;
+	static const int custom_phase ;
 	// death phases
-	static const int apoptotic=100;
-	static const int necrotic_swelling=101;
-	static const int necrotic_lysed=102;
-	static const int necrotic=103; 
-	static const int debris=104; 
+	static const int apoptotic;
+	static const int necrotic_swelling;
+	static const int necrotic_lysed;
+	static const int necrotic; 
+	static const int debris; 
 };
 extern std::string time_units;
 extern std::string space_units;


### PR DESCRIPTION
This may be premature, but would like to at least suggest it get merged in this release. This addresses compiler errors with `PhysiCell_constants{.h,.cpp}` for certain compilers (I had mentioned `clang++` when I need to do serious debugging, and issue https://github.com/MathCancer/PhysiCell/issues/236 mentioned the error on nvc++, as did @clasqui to @vincent-noel for PhysiBoSS). 

I've only tested with the "compile all the sample projects" script. Obviously, it would be good to test with actual simulations (EDIT: see next comment).