### PR TITLE
Throw error if duplicate substrate or parameter

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -475,146 +475,24 @@ void Microenvironment::add_density( void )
 {
 	// fix in PhysiCell preview November 2017 
 	// default_microenvironment_options.use_oxygen_as_first_field = false; 
-	
-	// update 1, 0 
-	zero.push_back( 0.0 ); 
-	one.push_back( 1.0 );
-	
-	// update units
-	density_names.push_back( "unnamed" ); 
-	density_units.push_back( "none" ); 
-
-	// update coefficients 
-	diffusion_coefficients.push_back( 0.0 ); 
-	decay_rates.push_back( 0.0 ); 
-	
-	// update sources and such 
-	for( unsigned int i=0; i < temporary_density_vectors1.size() ; i++ )
-	{
-		temporary_density_vectors1[i].push_back( 0.0 ); 
-		temporary_density_vectors2[i].push_back( 0.0 ); 
-	}
-
-	// resize the gradient data structures 
-	for( unsigned int k=0 ; k < mesh.voxels.size() ; k++ )
-	{
-		gradient_vectors[k].resize( number_of_densities() ); 
-		for( unsigned int i=0 ; i < number_of_densities() ; i++ )
-		{
-			(gradient_vectors[k])[i].resize( 3, 0.0 );
-		}
-	}
-
-	gradient_vector_computed.resize( mesh.voxels.size() , false ); 	
-	
-	one_half = one; 
-	one_half *= 0.5; 
-	
-	one_third = one; 
-	one_third /= 3.0; 
-	
-	dirichlet_value_vectors.assign( mesh.voxels.size(), one ); 
-	dirichlet_activation_vector.push_back( true ); 
-	dirichlet_activation_vectors.assign( mesh.voxels.size(), dirichlet_activation_vector ); 
-	
-	// Fixes in PhysiCell preview November 2017
-	default_microenvironment_options.Dirichlet_condition_vector.push_back( 1.0 ); //  = one; 
-	default_microenvironment_options.Dirichlet_activation_vector.push_back( false );
-	
-	default_microenvironment_options.initial_condition_vector.push_back( 1.0 ); 
-
-	default_microenvironment_options.Dirichlet_all.push_back( true ); 
-//	default_microenvironment_options.Dirichlet_interior.push_back( true );
-	default_microenvironment_options.Dirichlet_xmin.push_back( false ); 
-	default_microenvironment_options.Dirichlet_xmax.push_back( false ); 
-	default_microenvironment_options.Dirichlet_ymin.push_back( false ); 
-	default_microenvironment_options.Dirichlet_ymax.push_back( false ); 
-	default_microenvironment_options.Dirichlet_zmin.push_back( false ); 
-	default_microenvironment_options.Dirichlet_zmax.push_back( false ); 
-	
-	default_microenvironment_options.Dirichlet_xmin_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_xmax_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_ymin_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_ymax_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_zmin_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_zmax_values.push_back( 1.0 ); 
-	
-	return; 
+	return add_density( "unnamed" , "none" );
 }
 
 void Microenvironment::add_density( std::string name , std::string units )
 {
 	// fix in PhysiCell preview November 2017 
 	// default_microenvironment_options.use_oxygen_as_first_field = false; 
-	
-	// update 1, 0 
-	zero.push_back( 0.0 ); 
-	one.push_back( 1.0 );
-
-	// update units
-	density_names.push_back( name ); 
-	density_units.push_back( units ); 
-
-	// update coefficients 
-	diffusion_coefficients.push_back( 0.0 ); 
-	decay_rates.push_back( 0.0 ); 
-	
-	// update sources and such 
-	for( unsigned int i=0; i < temporary_density_vectors1.size() ; i++ )
-	{
-		temporary_density_vectors1[i].push_back( 0.0 ); 
-		temporary_density_vectors2[i].push_back( 0.0 ); 
-	}
-
-	// resize the gradient data structures, 
-	for( unsigned int k=0 ; k < mesh.voxels.size() ; k++ )
-	{
-		gradient_vectors[k].resize( number_of_densities() ); 
-		for( unsigned int i=0 ; i < number_of_densities() ; i++ )
-		{
-			(gradient_vectors[k])[i].resize( 3, 0.0 );
-		}
-	}
-	gradient_vector_computed.resize( mesh.voxels.size() , false ); 	
-
-	one_half = one; 
-	one_half *= 0.5; 
-	
-	one_third = one; 
-	one_third /= 3.0; 
-	
-	dirichlet_value_vectors.assign( mesh.voxels.size(), one ); 
-	dirichlet_activation_vector.push_back( false );
-	dirichlet_activation_vectors.assign( mesh.voxels.size(), dirichlet_activation_vector ); 
-	
-	// fix in PhysiCell preview November 2017 
-	default_microenvironment_options.Dirichlet_condition_vector.push_back( 1.0 ); //  = one; 
-	default_microenvironment_options.Dirichlet_activation_vector.push_back( false ); // assign( number_of_densities(), false ); 
-
-	default_microenvironment_options.Dirichlet_all.push_back( false );
-	default_microenvironment_options.Dirichlet_xmin.push_back( false ); 
-	default_microenvironment_options.Dirichlet_xmax.push_back( false ); 
-	default_microenvironment_options.Dirichlet_ymin.push_back( false ); 
-	default_microenvironment_options.Dirichlet_ymax.push_back( false ); 
-	default_microenvironment_options.Dirichlet_zmin.push_back( false ); 
-	default_microenvironment_options.Dirichlet_zmax.push_back( false ); 
-	
-	default_microenvironment_options.Dirichlet_xmin_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_xmax_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_ymin_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_ymax_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_zmin_values.push_back( 1.0 ); 
-	default_microenvironment_options.Dirichlet_zmax_values.push_back( 1.0 ); 	
-
-	default_microenvironment_options.initial_condition_vector.push_back( 1.0 ); 
-	
-	return; 
+	return add_density( name , units , 0.0 , 0.0 );
 }
 
 void Microenvironment::add_density( std::string name , std::string units, double diffusion_constant, double decay_rate )
 {
 	// fix in PhysiCell preview November 2017 
-	// default_microenvironment_options.use_oxygen_as_first_field = false; 
+	if ( find_density_index( name ) != -1 )
+	{
+		std::cout << "ERROR: density named " << name << " already exists. You probably want your substrates all have unique names!" << std::endl;
+		exit(-1); 
+	}
 	
 	// update 1, 0 
 	zero.push_back( 0.0 ); 

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -449,54 +449,28 @@ Parameters<T>::Parameters()
 template <class T>
 void Parameters<T>::add_parameter( std::string my_name )
 {
-	Parameter<T>* pNew; 
-	pNew = new Parameter<T> ;
-	pNew->name = my_name ; 
-	
-	int n = parameters.size(); 
-	
-	parameters.push_back( *pNew ); 
-	
-	name_to_index_map[ my_name ] = n; 
-	return; 
+	// this function is not currently (2024-06-03) called in the code, so these defaults largely do not matter; very unlikely others are directly calling this function, let alone this implementation
+	T my_value = T(); // for {int, double, bool, string} this will be {0, 0.0, false, ""} (this would technically change the behavior for strings since it is hardcoded above to default to "none", but nobody should rely on the default value of a string being "none")
+	return add_parameter( my_name , my_value );
 }
 
 template <class T>
 void Parameters<T>::add_parameter( std::string my_name , T my_value )
 {
-	Parameter<T>* pNew; 
-	pNew = new Parameter<T> ;
-	pNew->name = my_name ; 
-	pNew->value = my_value; 
-	
-	int n = parameters.size(); 
-	
-	parameters.push_back( *pNew ); 
-	
-	name_to_index_map[ my_name ] = n; 
-	return; 
+	// this function is not currently (2024-06-03) called in the code, so these defaults largely do not matter; very unlikely others are directly calling this function, let alone this implementation
+	std::string my_units = "dimensionless"; // technically this would change the behavior for strings since it is hardcoded above to default to "none", but nobody should be using units on strings; also, if the xml does not have units, then "dimensionless" is used even for strings
+	return add_parameter( my_name , my_value , my_units );
 }
-/*
-template <class T>
-void Parameters<T>::add_parameter( std::string my_name , T my_value )
-{
-	Parameter<T>* pNew; 
-	pNew = new Parameter<T> ;
-	pNew->name = my_name ; 
-	pNew->value = my_value; 
-	
-	int n = parameters.size(); 
-	
-	parameters.push_back( *pNew ); 
-	
-	name_to_index_map[ my_name ] = n; 
-	return; 
-}
-*/
 
 template <class T>
 void Parameters<T>::add_parameter( std::string my_name , T my_value , std::string my_units )
 {
+	if (exists(my_name))
+	{
+		std::cout << "ERROR: Parameter " << my_name << " already exists. Make sure all parameters (of a given type) have unique names." << std::endl;
+		exit(-1);
+	}
+
 	Parameter<T>* pNew; 
 	pNew = new Parameter<T> ;
 	pNew->name = my_name ; 
@@ -510,33 +484,26 @@ void Parameters<T>::add_parameter( std::string my_name , T my_value , std::strin
 	name_to_index_map[ my_name ] = n; 
 	return; 
 }
-
-/*
-template <class T>
-void Parameters<T>::add_parameter( std::string my_name , T my_value , std::string my_units )
-{
-	Parameter<T>* pNew; 
-	pNew = new Parameter<T> ;
-	pNew->name = my_name ; 
-	pNew->value = my_value; 
-	pNew->units = my_units; 
-	
-	int n = parameters.size(); 
-	
-	parameters.push_back( *pNew ); 
-	
-	name_to_index_map[ my_name ] = n; 
-	return; 
-}
-*/
 
 template <class T>
 void Parameters<T>::add_parameter( Parameter<T> param )
 {
+	if (exists(param.name))
+	{ exit(-1);}
+
 	int n = parameters.size(); 
 	parameters.push_back( param); 
 	name_to_index_map[ param.name ] = n; 
 	return; 
+}
+
+template <class T>
+bool Parameters<T>::exists( std::string search_name )
+{
+	if( find_index( search_name ) == -1 )
+	{ return false; }
+	std::cout << "ERROR: Parameter " << search_name << " already exists. Make sure all parameters (of a given type) have unique names." << std::endl;
+	return true;
 }
 
 std::ostream& operator<<( std::ostream& os , const User_Parameters up )
@@ -562,44 +529,33 @@ void User_Parameters::read_from_pugixml( pugi::xml_node parent_node )
 		{ units = "dimensionless"; } 
 		
 		std::string type = node1.attribute( "type" ).value();
-		
-		bool done = false ; 
-		if( type == "bool" && done == false )
+
+		if (type == "bool")
 		{
-			bool value = xml_get_my_bool_value( node1 ); 
-			bools.add_parameter( name , value, units ); 
-			done = true; 
+			bool value = xml_get_my_bool_value(node1);
+			bools.add_parameter(name, value, units);
 		}
-		
-		if( type == "int" && done == false )
+		else if (type == "int")
 		{
-			int value = xml_get_my_int_value( node1 ); 
-			ints.add_parameter( name , value, units ); 
-			done = true; 
+			int value = xml_get_my_int_value(node1);
+			ints.add_parameter(name, value, units);
 		}
-		
-		if( type == "double" && done == false )
+		else if (type == "double")
 		{
-			double value = xml_get_my_double_value( node1 ); 
-			doubles.add_parameter( name , value, units ); 
-			done = true; 
+			double value = xml_get_my_double_value(node1);
+			doubles.add_parameter(name, value, units);
 		}
-				
-		if( done == false && type == "string" )
+		else if (type == "string")
 		{
-			std::string value = xml_get_my_string_value( node1 ); 
-			strings.add_parameter( name, value , units ); 
-			done = true; 
+			std::string value = xml_get_my_string_value(node1);
+			strings.add_parameter(name, value, units);
 		}
-		
-		/* default if no type specified: */
-		if( done == false )
+		else // default if no type specified
 		{
-			double value = xml_get_my_double_value( node1 ); 
-			doubles.add_parameter( name , value, units ); 
-			done = true; 
+			double value = xml_get_my_double_value(node1);
+			doubles.add_parameter(name, value, units);
 		}
-		
+
 		node1 = node1.next_sibling(); 
 		i++; 
 	}

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -465,11 +465,7 @@ void Parameters<T>::add_parameter( std::string my_name , T my_value )
 template <class T>
 void Parameters<T>::add_parameter( std::string my_name , T my_value , std::string my_units )
 {
-	if (exists(my_name))
-	{
-		std::cout << "ERROR: Parameter " << my_name << " already exists. Make sure all parameters (of a given type) have unique names." << std::endl;
-		exit(-1);
-	}
+	assert_not_exists(my_name);
 
 	Parameter<T>* pNew; 
 	pNew = new Parameter<T> ;
@@ -488,8 +484,7 @@ void Parameters<T>::add_parameter( std::string my_name , T my_value , std::strin
 template <class T>
 void Parameters<T>::add_parameter( Parameter<T> param )
 {
-	if (exists(param.name))
-	{ exit(-1);}
+	assert_not_exists(param.name);
 
 	int n = parameters.size(); 
 	parameters.push_back( param); 
@@ -498,12 +493,13 @@ void Parameters<T>::add_parameter( Parameter<T> param )
 }
 
 template <class T>
-bool Parameters<T>::exists( std::string search_name )
+void Parameters<T>::assert_not_exists( std::string search_name )
 {
 	if( find_index( search_name ) == -1 )
-	{ return false; }
+	{ return; }
+
 	std::cout << "ERROR: Parameter " << search_name << " already exists. Make sure all parameters (of a given type) have unique names." << std::endl;
-	return true;
+	exit(-1);
 }
 
 std::ostream& operator<<( std::ostream& os , const User_Parameters up )

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -200,10 +200,9 @@ class Parameters
 	Parameter<T>& operator[]( int i );
 	Parameter<T>& operator[]( std::string str ); 
 	
-	int size( void ) const; 
+	int size( void ) const;
 
-	bool exists( std::string search_name );
-
+	void assert_not_exists(std::string search_name);
 };
 
 class User_Parameters

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -186,9 +186,7 @@ class Parameters
 	
 	void add_parameter( std::string my_name ); 
 	void add_parameter( std::string my_name , T my_value ); 
-//	void add_parameter( std::string my_name , T my_value ); 
 	void add_parameter( std::string my_name , T my_value , std::string my_units ); 
-//	void add_parameter( std::string my_name , T my_value , std::string my_units ); 
 	
 	void add_parameter( Parameter<T> param );
 	
@@ -203,6 +201,9 @@ class Parameters
 	Parameter<T>& operator[]( std::string str ); 
 	
 	int size( void ) const; 
+
+	bool exists( std::string search_name );
+
 };
 
 class User_Parameters


### PR DESCRIPTION
Check that each added substrate has a unique name. Same for parameters (for a given type).

Also, clean up some code to improve maintainability/readability.

Suggestion for future improvement: rename some of the many instances of "parameters" in the code. For example, UserParameters has one instance called parameters. Each instance of Parameters has a member called parameters. Many other objects in PhysiCell have parameters members. This makes it hard to track which ones belong where.