### PR TITLE
set default substrate color fn to give easy access to all projects

### DIFF
--- a/modules/PhysiCell_pathology.h
+++ b/modules/PhysiCell_pathology.h
@@ -122,7 +122,7 @@ std::vector<std::string> paint_by_number_cell_coloring( Cell* pCell ); // done
 
 std::string formatted_minutes_to_DDHHMM( double minutes ); 
 
-void SVG_plot( std::string filename , Microenvironment& M, double z_slice , double time, std::vector<std::string> (*cell_coloring_function)(Cell*), std::string (*substrate_coloring_function)(double, double, double) = NULL, void (*cell_counts_function) (char*) = NULL); // done
+void SVG_plot( std::string filename , Microenvironment& M, double z_slice , double time, std::vector<std::string> (*cell_coloring_function)(Cell*), std::string (*substrate_coloring_function)(double, double, double) = paint_by_density_percentage, void (*cell_counts_function) (char*) = NULL); // done
 
 void SVG_plot_with_stroma( std::string filename , Microenvironment& M, double z_slice , double time, std::vector<std::string> (*cell_coloring_function)(Cell*) , 
 	int ECM_index, std::vector<std::string> (*ECM_coloring_function)(double) ); // planned


### PR DESCRIPTION
anybody can use the substrate coloring on svgs just by editing the config file, i.e. just by using studio. thanks @rheiland for the great suggestion!