### PR TITLE
random seed within options

### DIFF
--- a/core/PhysiCell_utilities.cpp
+++ b/core/PhysiCell_utilities.cpp
@@ -78,9 +78,21 @@ thread_local bool local_pnrg_setup_done = false;
 unsigned int physicell_random_seed = 0; 
 std::vector<unsigned int> physicell_random_seeds; 
 
-void SeedRandom( unsigned int input )
-{ 
-	physicell_random_seed = input;
+void setup_rng( void )
+{
+	static bool setup_done = false;
+	static bool warned = false;
+	if (!warned && setup_done)
+	{
+		std::cout << "WARNING: Setting the random seed again." << std::endl
+				  << "\tYou probably have..." << std::endl
+				  << "\t\t1. added a random seed element to options in the config file AND" << std::endl
+				  << "\t\t2. set a user parameter called random seed." << std::endl
+				  << "\tFuture versions of PhysiCell may throw an error here. Kindly remove the user parameter and just use the <options><random_seed> element." << std::endl;
+		// exit(-1);
+		warned = true;
+	}
+	std::cout << "Setting up RNG with seed " << physicell_random_seed << std::endl;
 	physicell_PRNG_generator.seed( physicell_random_seed );
 
 	// now get number of threads and set up a seed for each thread 
@@ -107,39 +119,20 @@ void SeedRandom( unsigned int input )
 	for( int i=1; i < num_threads ; i++ )
 	{ physicell_random_seeds[i] = seeds[i]; }
 
+	setup_done = true;
 	return; 
+}
+
+void SeedRandom( unsigned int input )
+{ 
+	physicell_random_seed = input;
+	return setup_rng();
 }
 
 void SeedRandom( void )
 { 
 	physicell_random_seed = std::chrono::system_clock::now().time_since_epoch().count();
-	physicell_PRNG_generator.seed( physicell_random_seed );
-
-	// now get number of threads and set up a seed for each thread 
-	int num_threads = PhysiCell_settings.omp_num_threads; 
-	physicell_random_seeds.resize( num_threads, 0 ); 
-
-	// use std::seed_seq to create a sequence of seeds 
-	// first, use the base seed 
-	std::vector<unsigned int> initial_sequence( num_threads , 0 ); 
-	// int* initial_sequence; 
-	// initial_sequence = new int [num_threads]; 
-	for( int i=0; i < num_threads ; i++ )
-	{ initial_sequence[i] = physicell_random_seed+i; } 
-	
-	// now we use std::seed_seq 
-	std::seed_seq seq(initial_sequence.begin() , initial_sequence.end() ); 
-
-	// now we call the generator 
-    std::vector<std::uint32_t> seeds(num_threads);
-    seq.generate(seeds.begin(), seeds.end());
-
-	// now transfer these into the seeds for each thread 
-	physicell_random_seeds[0] = physicell_random_seed; 
-	for( int i=1; i < num_threads ; i++ )
-	{ physicell_random_seeds[i] = seeds[i]; }
-
-	return; 
+	return setup_rng();
 }
 
 double UniformRandom_old_not_thread_safe()

--- a/core/PhysiCell_utilities.h
+++ b/core/PhysiCell_utilities.h
@@ -83,7 +83,7 @@ namespace PhysiCell{
 
 	extern std::vector<unsigned int> physicell_random_seeds; 
 
-
+void setup_rng( void );
 void SeedRandom( unsigned int input );
 void SeedRandom( void );
 

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -237,32 +237,44 @@ void PhysiCell_Settings::read_from_pugixml( void )
 	
 	pugi::xml_node node_options; 
 	
-	node_options = xml_find_node( physicell_config_root , "options" ); 
-	if( node_options )
+	node_options = xml_find_node( physicell_config_root , "options" );
+	if (node_options)
 	{
-		bool settings; 
-		
-		// look for legacy_random_points_on_sphere_in_divide 
-		settings = 
-			xml_get_bool_value( node_options, "legacy_random_points_on_sphere_in_divide" ); 
-		if( settings )
+		bool settings;
+
+		// look for legacy_random_points_on_sphere_in_divide
+		settings = xml_get_bool_value(node_options, "legacy_random_points_on_sphere_in_divide");
+		if (settings)
 		{
-			std::cout << "setting legacy unif" << std::endl; 
-			extern std::vector<double> (*cell_division_orientation)(void); 
-			cell_division_orientation = LegacyRandomOnUnitSphere; 
-		}
-	
-		settings = xml_get_bool_value( node_options, "disable_automated_spring_adhesions" ); 
-		if( settings )
-		{
-			std::cout << "Disabling automated spring adhesions and detachments!" << std::endl; 
-			PhysiCell_settings.disable_automated_spring_adhesions = true; 
+			std::cout << "setting legacy unif" << std::endl;
+			extern std::vector<double> (*cell_division_orientation)(void);
+			cell_division_orientation = LegacyRandomOnUnitSphere;
 		}
 
-		// other options can go here, eventually 
+		settings = xml_get_bool_value(node_options, "disable_automated_spring_adhesions");
+		if (settings)
+		{
+			std::cout << "Disabling automated spring adhesions and detachments!" << std::endl;
+			PhysiCell_settings.disable_automated_spring_adhesions = true;
+		}
 
+		pugi::xml_node random_seed_node = xml_find_node(node_options, "random_seed");
+		std::string random_seed = "";
+		if (random_seed_node)
+		{ random_seed = xml_get_my_string_value(random_seed_node); }
+		if (random_seed == "" || random_seed == "random" || random_seed == "system_clock")
+		{
+			std::cout << "Using system clock for random seed" << std::endl;
+			SeedRandom();
+		}
+		else
+		{
+			SeedRandom(std::stoi(random_seed));
+		}
+
+		// other options can go here, eventually
 	}
-	
+
 	// domain options 
 	
 	node = xml_find_node( physicell_config_root , "domain" );

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -269,7 +269,15 @@ void PhysiCell_Settings::read_from_pugixml( void )
 		}
 		else
 		{
-			SeedRandom(std::stoi(random_seed));
+			int seed;
+			try
+			{ seed = std::stoi(random_seed); }
+			catch(const std::exception& e)
+			{
+				std::cout << "ERROR: " << random_seed << " is not a valid random seed. It must be an integer. Fix this within <options>." << std::endl;
+				exit(-1);
+			}
+			SeedRandom(seed);
 		}
 
 		// other options can go here, eventually

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -259,9 +259,10 @@ void PhysiCell_Settings::read_from_pugixml( void )
 		}
 
 		pugi::xml_node random_seed_node = xml_find_node(node_options, "random_seed");
-		std::string random_seed = "";
+		std::string random_seed = ""; // default is system clock, even if this element is not present
 		if (random_seed_node)
 		{ random_seed = xml_get_my_string_value(random_seed_node); }
+
 		if (random_seed == "" || random_seed == "random" || random_seed == "system_clock")
 		{
 			std::cout << "Using system clock for random seed" << std::endl;

--- a/sample_projects/biorobots/custom_modules/custom.cpp
+++ b/sample_projects/biorobots/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/cancer_biorobots/custom_modules/custom.cpp
+++ b/sample_projects/cancer_biorobots/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/celltypes3/custom_modules/custom.cpp
+++ b/sample_projects/celltypes3/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/heterogeneity/custom_modules/custom.cpp
+++ b/sample_projects/heterogeneity/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/interactions/custom_modules/custom.cpp
+++ b/sample_projects/interactions/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/mechano/custom_modules/custom.cpp
+++ b/sample_projects/mechano/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/physimess/custom_modules/custom.cpp
+++ b/sample_projects/physimess/custom_modules/custom.cpp
@@ -72,7 +72,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/pred_prey_farmer/custom_modules/custom.cpp
+++ b/sample_projects/pred_prey_farmer/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/rules_sample/custom_modules/custom.cpp
+++ b/sample_projects/rules_sample/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/template/config/PhysiCell_settings.xml
+++ b/sample_projects/template/config/PhysiCell_settings.xml
@@ -128,6 +128,7 @@
 		<legacy_random_points_on_sphere_in_divide>false</legacy_random_points_on_sphere_in_divide>
 		<virtual_wall_at_domain_edge>true</virtual_wall_at_domain_edge>
         <disable_automated_spring_adhesions>false</disable_automated_spring_adhesions>
+		<random_seed />
 	</options>	
 
 	<microenvironment_setup>

--- a/sample_projects/template/custom_modules/custom.cpp
+++ b/sample_projects/template/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/virus_macrophage/custom_modules/custom.cpp
+++ b/sample_projects/virus_macrophage/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects/worm/custom_modules/custom.cpp
+++ b/sample_projects/worm/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects_intracellular/boolean/cancer_invasion/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/cancer_invasion/custom_modules/custom.cpp
@@ -73,7 +73,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/custom_modules/custom.cpp
@@ -76,7 +76,10 @@ std::vector<bool> nodes;
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects_intracellular/boolean/template_BM/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/template_BM/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects_intracellular/boolean/tutorial/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/boolean/tutorial/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects_intracellular/fba/cancer_metabolism/custom_modules/cancer_metabolism.cpp
+++ b/sample_projects_intracellular/fba/cancer_metabolism/custom_modules/cancer_metabolism.cpp
@@ -72,7 +72,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/sample_projects_intracellular/ode/ode_energy/custom_modules/custom.cpp
+++ b/sample_projects_intracellular/ode/ode_energy/custom_modules/custom.cpp
@@ -78,7 +78,10 @@ extern "C" rrc::RRHandle createRRInstance();
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/unit_tests/custom_DCs_2substrates/custom_modules/custom.cpp
+++ b/unit_tests/custom_DCs_2substrates/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/unit_tests/custom_DCs_2substrates/custom_modules/custom_v1.cpp
+++ b/unit_tests/custom_DCs_2substrates/custom_modules/custom_v1.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/unit_tests/custom_DCs_2substrates/custom_modules/custom_v2.cpp
+++ b/unit_tests/custom_DCs_2substrates/custom_modules/custom_v2.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 

--- a/unit_tests/custom_voxel_values/custom_modules/custom.cpp
+++ b/unit_tests/custom_voxel_values/custom_modules/custom.cpp
@@ -70,7 +70,10 @@
 void create_cell_types( void )
 {
 	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
+	if (parameters.ints.find_index("random_seed") != -1)
+	{
+		SeedRandom(parameters.ints("random_seed"));
+	}
 	
 	/* 
 	   Put any modifications to default cell definition here if you 


### PR DESCRIPTION
allow for node in `<options>` element that contains random seed info. see examples below. As discussed, the template project will continue to support the `random_seed` user parameter and will in fact use this to overwrite the random_seed in options. further remarks:
* `random_seed` intentionally used to match with user parameter to help draw attention for users
* a warning is issued if both are provided that someone other than me may one day see and convince them to keep only the random_seed in options

Random thought: we should write some of the console output to a file to focus attention on warnings that go flying by. also throttle updates on saves based on wall time passed.

# set by int (`SeedRandom( i )`)
```
<options>
...
    <random_seed>0</random_seed>
</options>
```
# set by system clock (`SeedRandom()`)
```
<options>
...
    <random_seed />
</options>
```
```
<options>
...
    <random_seed>system_clock</random_seed>
</options>
```
```
<options>
...
    <random_seed>random</random_seed>
</options>
```
