### PR TITLE
Fix substrate colorbar label placement for jpeg conversion

### DIFF
--- a/modules/PhysiCell_SVG.cpp
+++ b/modules/PhysiCell_SVG.cpp
@@ -108,7 +108,9 @@ void Write_SVG_text(std::ostream& os, const char* str , double position_x, doubl
     double center_x = position_x + text_width / 2.0;
     double center_y = position_y + text_height / 2.0;
 
-    os << "<text x=\"" << position_x << "\" y=\"" << position_y << "\" font-size=\"" << font_size << "\" fill=\"" << color << "\" font-family=\"" << font << "\" transform=\"rotate(" << rotation << " " << center_x << " " << center_y << ")\">" << str << "</text>\n";
+    os << "  <g transform=\"rotate(" << rotation << " " << center_x << " " << center_y << ")\">" << std::endl;
+    os << "    <text x=\"" << position_x << "\" y=\"" << position_y << "\" font-size=\"" << font_size << "\" fill=\"" << color << "\" font-family=\"" << font << "\">" << str << "</text>\n";
+    os << "  </g>" << std::endl;
 }
 
 bool Write_SVG_circle( std::ostream& os, double center_x, double center_y, double radius, double stroke_size, 

--- a/modules/PhysiCell_pathology.cpp
+++ b/modules/PhysiCell_pathology.cpp
@@ -472,8 +472,15 @@ void SVG_plot(std::string filename, Microenvironment &M, double z_slice, double 
 	Write_SVG_text( os, szString, font_size*0.5,  font_size*(.2+1+.2+.9), 
 		0.95*font_size, PhysiCell_SVG_options.font_color.c_str() , PhysiCell_SVG_options.font.c_str() );
 	
-	delete [] szString; 
+	delete [] szString;
 
+	if (PhysiCell_settings.enable_substrate_plot == true && (*substrate_coloring_function) != NULL)
+	{
+		// add an outer "g" for coordinate transforms
+		double upper_left_x = plot_width + 25.0;
+		Write_SVG_text(os, PhysiCell_settings.substrate_to_monitor.c_str(), upper_left_x + 35, top_margin + plot_height / 2, font_size,
+					   PhysiCell_SVG_options.font_color.c_str(), PhysiCell_SVG_options.font.c_str(), 90.0);
+	}
 
 	// add an outer "g" for coordinate transforms 
 
@@ -746,10 +753,6 @@ void SVG_plot(std::string filename, Microenvironment &M, double z_slice, double 
 			PhysiCell_SVG_options.font_color.c_str() , PhysiCell_SVG_options.font.c_str() ); // misterious values set with a trial and error approach due to OCD. But now the legend is coherent at pixel level
 
 		delete [] szString;
-
-		// add a label to the right of the colorbar defined by above Write_SVG_rect calls
-		Write_SVG_text(os, PhysiCell_settings.substrate_to_monitor.c_str(), upper_left_x + 35, top_margin + plot_height / 2, font_size,
-					   PhysiCell_SVG_options.font_color.c_str(), PhysiCell_SVG_options.font.c_str(), 90.0);
 	}
 
 	Write_SVG_rect(os, 25.0 + plot_width, top_margin, 25.0, plot_height - 25, 0.002 * plot_height , "black", "none"); // nice black contour around the legend


### PR DESCRIPTION
For some reason I cannot comprehend, the svg->jpeg conversion does not like individual text elements having a rotation, so now the substrate colorbar label is placed in a group that is rotated.

For another reason I cannot comprehend, the ordering of the svg elements affects how this rotation happens. If I move the substrate colorbar label up, then it is placed in the right place upon conversion to a jpeg.

### Before fix
<img width="1220" alt="image" src="https://github.com/MathCancer/PhysiCell/assets/22732264/0dd6c548-6e60-4ecf-b9f2-698b3e29b7c6">

### After fix
<img width="1220" alt="image" src="https://github.com/MathCancer/PhysiCell/assets/22732264/adde874e-88df-4cee-bdc6-2707223f5b31">


