### PR TITLE
Makefile save function sets the PROJ variable in the Makefile to the actual name the project was saved with.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,8 +490,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/Makefile
+++ b/Makefile
@@ -394,9 +394,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ data-cleanup:
 # archival 
 
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/Makefile
+++ b/Makefile
@@ -387,17 +387,17 @@ PhysiCell_geometry.o: ./modules/PhysiCell_geometry.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp PhysiCell_cell.o
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm ./config/*.csv	
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/Makefile
+++ b/Makefile
@@ -493,15 +493,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/Makefile
+++ b/Makefile
@@ -491,6 +491,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -490,8 +490,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -394,9 +394,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -410,7 +410,7 @@ data-cleanup:
 # archival 
 
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -387,16 +387,18 @@ PhysiCell_geometry.o: ./modules/PhysiCell_geometry.cpp
 # cleanup
 
 reset:
+	make clean
 	rm -f *.cpp PhysiCell_cell.o
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
 	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 	touch ./config/empty.csv
-	rm ./config/*.csv	
 	
 clean:
 	rm -f *.o

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -493,15 +493,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -388,8 +388,7 @@ PhysiCell_geometry.o: ./modules/PhysiCell_geometry.cpp
 
 reset:
 	make clean
-	rm -f *.cpp PhysiCell_cell.o
-	touch ./core/PhysiCell_cell.cpp
+	rm -f *.cpp
 	cp ./sample_projects/Makefile-default Makefile
 	rm -fr ./custom_modules/*
 	touch ./custom_modules/empty.txt
@@ -398,8 +397,7 @@ reset:
 	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
 	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
-	touch ./config/empty.csv
-	
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -491,6 +491,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/PhysiCell_settings.xml-default
+++ b/sample_projects/PhysiCell_settings.xml-default
@@ -1,0 +1,271 @@
+<PhysiCell_settings version="devel-version">
+
+    <domain>
+        <x_min>-500</x_min>
+        <x_max>500</x_max>
+        <y_min>-500</y_min>
+        <y_max>500</y_max>
+        <z_min>-10</z_min>
+        <z_max>10</z_max>
+        <dx>20</dx>
+        <dy>20</dy>
+        <dz>20</dz>
+        <use_2D>true</use_2D>
+    </domain>
+
+    <overall>
+        <max_time units="min">14400</max_time>
+        <time_units>min</time_units>
+        <space_units>micron</space_units>
+        <dt_diffusion units="min">0.01</dt_diffusion>
+        <dt_mechanics units="min">0.1</dt_mechanics>
+        <dt_phenotype units="min">6</dt_phenotype>
+    </overall>
+
+    <parallel>
+        <omp_num_threads>6</omp_num_threads>
+    </parallel>
+
+    <save>
+        <folder>output</folder>
+        <full_data>
+            <interval units="min">60</interval>
+            <enable>true</enable>
+        </full_data>
+        <SVG>
+            <interval units="min">60</interval>
+            <enable>true</enable>
+        </SVG>
+        <legacy_data>
+            <enable>false</enable>
+        </legacy_data>
+    </save>
+
+    <options>
+        <legacy_random_points_on_sphere_in_divide>false</legacy_random_points_on_sphere_in_divide>
+        <virtual_wall_at_domain_edge>true</virtual_wall_at_domain_edge>
+    </options>
+
+    <microenvironment_setup>
+        <variable name="oxygen" units="dimensionless" ID="0">
+            <physical_parameter_set>
+                <diffusion_coefficient units="micron^2/min">100000.0</diffusion_coefficient>
+                <decay_rate units="1/min">0.1</decay_rate>
+            </physical_parameter_set>
+            <initial_condition units="mmHg">38</initial_condition>
+            <Dirichlet_boundary_condition units="mmHg" enabled="True">0</Dirichlet_boundary_condition>
+            <Dirichlet_options>
+                <boundary_value ID="xmin" enabled="True">38</boundary_value>
+                <boundary_value ID="xmax" enabled="True">10</boundary_value>
+                <boundary_value ID="ymin" enabled="True">10</boundary_value>
+                <boundary_value ID="ymax" enabled="True">38</boundary_value>
+                <boundary_value ID="zmin" enabled="False">0</boundary_value>
+                <boundary_value ID="zmax" enabled="False">0</boundary_value>
+            </Dirichlet_options>
+        </variable>
+        <variable name="necrotic debris" units="dimensionless" ID="1">
+            <physical_parameter_set>
+                <diffusion_coefficient units="micron^2/min">10</diffusion_coefficient>
+                <decay_rate units="1/min">.1</decay_rate>
+            </physical_parameter_set>
+            <initial_condition units="mmHg">0</initial_condition>
+            <Dirichlet_boundary_condition units="mmHg" enabled="False">0</Dirichlet_boundary_condition>
+            <Dirichlet_options>
+                <boundary_value ID="xmin" enabled="False">0</boundary_value>
+                <boundary_value ID="xmax" enabled="False">0</boundary_value>
+                <boundary_value ID="ymin" enabled="False">0</boundary_value>
+                <boundary_value ID="ymax" enabled="False">0</boundary_value>
+                <boundary_value ID="zmin" enabled="False">0</boundary_value>
+                <boundary_value ID="zmax" enabled="False">0</boundary_value>
+            </Dirichlet_options>
+        </variable>
+        <variable name="apoptotic debris" units="dimensionless" ID="2">
+            <physical_parameter_set>
+                <diffusion_coefficient units="micron^2/min">10</diffusion_coefficient>
+                <decay_rate units="1/min">0.1</decay_rate>
+            </physical_parameter_set>
+            <initial_condition units="mmHg">0</initial_condition>
+            <Dirichlet_boundary_condition units="mmHg" enabled="False">0</Dirichlet_boundary_condition>
+            <Dirichlet_options>
+                <boundary_value ID="xmin" enabled="False">0</boundary_value>
+                <boundary_value ID="xmax" enabled="False">0</boundary_value>
+                <boundary_value ID="ymin" enabled="False">0</boundary_value>
+                <boundary_value ID="ymax" enabled="False">0</boundary_value>
+                <boundary_value ID="zmin" enabled="False">0</boundary_value>
+                <boundary_value ID="zmax" enabled="False">0</boundary_value>
+            </Dirichlet_options>
+        </variable>
+        <options>
+            <calculate_gradients>true</calculate_gradients>
+            <track_internalized_substrates_in_each_agent>true</track_internalized_substrates_in_each_agent>
+            <initial_condition type="matlab" enabled="false">
+                <filename>./config/initial.mat</filename>
+            </initial_condition>
+            <dirichlet_nodes type="matlab" enabled="false">
+                <filename>./config/dirichlet.mat</filename>
+            </dirichlet_nodes>
+        </options>
+    </microenvironment_setup>
+
+    <cell_definitions>
+        <cell_definition name="malignant epithelial" ID="0">
+            <phenotype>
+                <cycle code="5" name="live">
+                    <phase_transition_rates units="1/min">
+                        <rate start_index="0" end_index="0" fixed_duration="false">0.000</rate>
+                    </phase_transition_rates>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">5.31667e-05</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">516</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">2.80E-03</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">0</duration>
+                            <duration index="1" fixed_duration="true">86400</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0</calcified_fraction>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="malignant epithelial">1</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <cell_BM_adhesion_strength units="micron/min">4.0</cell_BM_adhesion_strength>
+                    <cell_BM_repulsion_strength units="micron/min">10.0</cell_BM_repulsion_strength>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.5</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>false</enabled>
+                            <substrate>oxygen</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
+                                <chemotactic_sensitivity substrate="necrotic debris">0.0</chemotactic_sensitivity>
+                                <chemotactic_sensitivity substrate="apoptotic debris">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="oxygen">
+                        <secretion_rate units="1/min">0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">10</uptake_rate>
+                        <net_export_rate units="total substrate/min">0</net_export_rate>
+                    </substrate>
+                    <substrate name="necrotic debris">
+                        <secretion_rate units="1/min">0.0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">0.0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0.0</net_export_rate>
+                    </substrate>
+                    <substrate name="apoptotic debris">
+                        <secretion_rate units="1/min">0.0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">0.0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0.0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <dead_phagocytosis_rate units="1/min">0</dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="malignant epithelial" units="1/min">0</phagocytosis_rate>
+                        <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="malignant epithelial" units="1/min">0</attack_rate>
+                        <attack_rate name="default" units="1/min">0</attack_rate>
+                    </attack_rates>
+                    <damage_rate units="1/min">1</damage_rate>
+                    <fusion_rates>
+                        <fusion_rate name="malignant epithelial" units="1/min">0</fusion_rate>
+                        <fusion_rate name="default" units="1/min">0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="malignant epithelial" units="1/min">0</transformation_rate>
+                        <transformation_rate name="default" units="1/min">0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+            </phenotype>
+            <custom_data>
+                <sample conserved="false" units="dimensionless" description="">1.0</sample>
+            </custom_data>
+        </cell_definition>
+    </cell_definitions>
+
+    <initial_conditions>
+        <cell_positions type="csv" enabled="true">
+            <folder>./config</folder>
+            <filename>cells.csv</filename>
+        </cell_positions>
+    </initial_conditions>
+
+    <cell_rules>
+        <rulesets>
+            <ruleset protocol="CBHG" version="2.0" format="csv" enabled="true">
+                <folder>./config</folder>
+                <filename>cell_rules_v2.csv</filename>
+            </ruleset>
+        </rulesets>
+        <settings />
+    </cell_rules>
+
+
+    <user_parameters>
+        <random_seed type="int" units="dimensionless" description="">0</random_seed>
+        <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">0</number_of_cells>
+    </user_parameters>
+</PhysiCell_settings>

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -179,9 +179,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -281,15 +281,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -195,7 +195,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -281,6 +281,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -172,15 +172,17 @@ cancer_immune_3D.o: ./custom_modules/cancer_immune_3D.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -280,8 +280,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -171,17 +171,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -178,9 +178,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/mechano/Makefile
+++ b/sample_projects/mechano/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/mechano/Makefile
+++ b/sample_projects/mechano/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/mechano/Makefile
+++ b/sample_projects/mechano/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/mechano/Makefile
+++ b/sample_projects/mechano/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/mechano/Makefile
+++ b/sample_projects/mechano/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -196,9 +196,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -189,18 +189,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/mymodel.xml *.csv
-	rm -fr ./config/Cell_Fibre_Mechanics ./config/Fibre_Crosslinks ./config/Fibre_Initialisation ./config/Neighbours_in_voxels ./config/Fibre_Degradation
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -212,7 +212,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -303,8 +303,8 @@ load:
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp -r ./user_projects/$(PROJ)/config/* ./config/ 
-	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -293,6 +293,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -292,8 +292,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -278,8 +278,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv 
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -281,15 +281,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -279,6 +279,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv 
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -278,6 +278,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -280,15 +280,15 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -277,8 +277,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -323,8 +323,8 @@ load:
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp -r ./user_projects/$(PROJ)/config/* ./config/ 
-	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -220,24 +220,26 @@ custom.o: ./custom_modules/custom.cpp $(MaBoSS)
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	rm ALL_CITATIONS.txt 
-	rm ./config/PhysiCell_settings_*.xml
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	rm -rf ./config/boolean_network/ ./config/cells.csv ./config/rules.csv ./config/init.tsv
+	make MaBoSS-clean
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:
 	rm -fr addons/PhysiBoSS/MaBoSS-env-2.0
-	
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*
-	
+
 data-cleanup:
 	rm -f *.mat
 	rm -f *.xml
@@ -245,7 +247,7 @@ data-cleanup:
 	rm -rf ./output
 	mkdir ./output
 	touch ./output/empty.txt
-	
+
 # archival 
 
 checkpoint: 

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -251,7 +251,7 @@ data-cleanup:
 # archival 
 
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -228,9 +228,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -315,8 +315,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -316,6 +316,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -312,6 +312,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -247,7 +247,7 @@ data-cleanup:
 # archival 
 
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -225,9 +225,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -217,31 +217,33 @@ custom.o: ./custom_modules/custom.cpp $(MaBoSS)
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	rm -rf ./config/model_*.bnd ./config/model.cfg ./config/cells.csv
+	make MaBoSS-clean
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:
 	rm -fr addons/PhysiBoSS/MaBoSS-env-2.0
-	
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*
-	
+
 data-cleanup:
 	rm -f *.mat
 	rm -f *.xml
 	rm -f *.svg
 	rm -f ./output/*
 	touch ./output/empty.txt
-	
+
 # archival 
 
 checkpoint: 

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -319,8 +319,8 @@ load:
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp -r ./user_projects/$(PROJ)/config/* ./config/ 
-	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -311,8 +311,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -225,9 +225,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -217,40 +217,42 @@ custom.o: ./custom_modules/custom.cpp $(MaBoSS)
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	rm -fr ./config/cells.csv ./config/cell_rules.csv
+	make MaBoSS-clean
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:
 	rm -fr addons/PhysiBoSS/MaBoSS-env-2.0
-	
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*
-	
+
 data-cleanup:
 	rm -rf ./output
 	mkdir ./output
 	touch ./output/empty.txt
-	
+
 # archival 
-	
+
 checkpoint: 
 	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
-	
+
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 
 	cp latest.zip $$(date +%b_%d_%Y_%H%M).zip
 	cp latest.zip VERSION_$(VERSION).zip 
 	mv *.zip archives/
-	
+
 tar:
 	tar --ignore-failed-read -czf latest.tar Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 
 	cp latest.tar $$(date +%b_%d_%Y_%H%M).tar
@@ -260,7 +262,7 @@ tar:
 unzip: 
 	cp ./archives/latest.zip . 
 	unzip latest.zip 
-	
+
 untar: 
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -245,7 +245,7 @@ data-cleanup:
 # archival 
 
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -325,8 +325,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -326,6 +326,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -333,8 +333,8 @@ load:
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp -r ./user_projects/$(PROJ)/config/* ./config/ 
-	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -324,8 +324,8 @@ load:
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp -r ./user_projects/$(PROJ)/config/* ./config/ 
-	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 pack:
 	@echo " "

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -251,7 +251,7 @@ data-cleanup:
 # archival 
 
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -228,9 +228,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -315,8 +315,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -220,25 +220,26 @@ custom.o: ./custom_modules/custom.cpp $(MaBoSS)
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	rm -rf ./config/simple_tnf/
-	rm -fr ./config/cell_cycle/
-	rm -fr ./config/differentiation/
+	make MaBoSS-clean
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 	rm -rf ./scripts
 
 MaBoSS-clean:
 	rm -fr addons/PhysiBoSS/MaBoSS-env-2.0
-	
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*
-	
+
 data-cleanup:
 	rm -f *.mat
 	rm -f *.xml
@@ -246,7 +247,7 @@ data-cleanup:
 	rm -rf ./output
 	mkdir ./output
 	touch ./output/empty.txt
-	
+
 # archival 
 
 checkpoint: 

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -316,6 +316,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/sample_projects_intracellular/fba/cancer_metabolism/Make-windows
+++ b/sample_projects_intracellular/fba/cancer_metabolism/Make-windows
@@ -198,14 +198,16 @@ cancer_metabolism.o: ./custom_modules/cancer_metabolism.cpp
 # cleanup
 
 reset:
+	make clean
 	rm -f *.cpp
 	cp ./sample_projects/Makefile-default Makefile
-	rm -f ./custom_modules/*
+	rm -fr ./custom_modules/*
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	cp ./config/PhysiCell_settings_default.xml ./config/PhysiCell_settings.xml
-	touch ./config/empty.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects_intracellular/fba/cancer_metabolism/Make-windows
+++ b/sample_projects_intracellular/fba/cancer_metabolism/Make-windows
@@ -205,9 +205,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects_intracellular/fba/cancer_metabolism/Makefile
+++ b/sample_projects_intracellular/fba/cancer_metabolism/Makefile
@@ -210,9 +210,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects_intracellular/fba/cancer_metabolism/Makefile
+++ b/sample_projects_intracellular/fba/cancer_metabolism/Makefile
@@ -203,16 +203,16 @@ cancer_metabolism.o: ./custom_modules/cancer_metabolism.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm ./config/*.csv	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
+++ b/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
@@ -276,7 +276,7 @@ data-cleanup:
 # archival
 
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/*

--- a/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
+++ b/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
@@ -251,15 +251,16 @@ ecoli_acetic_switch.o: ./custom_modules/ecoli_acetic_switch.cpp
 # cleanup
 
 reset:
+	make clean
 	rm -f *.cpp
 	cp ./sample_projects/Makefile-default Makefile
-	rm -f ./custom_modules/*
+	rm -fr ./custom_modules/*
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
-	touch ./core/PhysiCell_cell.cpp
 	rm ALL_CITATIONS.txt
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
-	touch ./config/empty.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
+++ b/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
@@ -258,9 +258,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -248,7 +248,7 @@ movie:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -234,9 +234,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 FOLDER := output
 FRAMERATE := 24

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -227,20 +227,16 @@ data-cleanup:
 	touch ./output/empty.txt
 
 reset:
-	rm -f *.cpp PhysiCell_cell.o
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm ./config/*.csv
-	rm ./config/*.m
-	rm ./config/*.cps
-	rm ./config/Toy_Metabolic_Model.xml
-
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
 
 FOLDER := output
 FRAMERATE := 24

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -278,8 +278,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -281,16 +281,16 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 # useage: make load PROJ=your_project_name
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 # useage: make share PROJ=your_project_name
 share: 

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -197,7 +197,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -279,6 +279,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -181,9 +181,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -174,17 +174,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -171,17 +171,17 @@ custom.o: ./custom_modules/custom.cpp
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	touch ./core/PhysiCell_cell.cpp
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.csv
-	rm -f ./config/*.csv
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -276,6 +276,7 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
+	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -178,9 +178,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -278,16 +278,16 @@ save:
 	cp main.cpp ./user_projects/$(PROJ)
 	cp Makefile ./user_projects/$(PROJ)
 	cp VERSION.txt ./user_projects/$(PROJ)
-	cp ./config/* ./user_projects/$(PROJ)/config
-	cp ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
+	cp -r ./config/* ./user_projects/$(PROJ)/config
+	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules
 
 # useage: make load PROJ=your_project_name
 load: 
 	echo "Loading project from $(PROJ) ... "
 	cp ./user_projects/$(PROJ)/main.cpp .
 	cp ./user_projects/$(PROJ)/Makefile .
-	cp ./user_projects/$(PROJ)/config/* ./config/ 
-	cp ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/ 
+	cp -r ./user_projects/$(PROJ)/config/* ./config/
+	cp -r ./user_projects/$(PROJ)/custom_modules/* ./custom_modules/
 
 # useage: make share PROJ=your_project_name
 share: 

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -275,8 +275,8 @@ save:
 	mkdir -p ./user_projects/$(PROJ)/custom_modules
 	mkdir -p ./user_projects/$(PROJ)/config 
 	cp main.cpp ./user_projects/$(PROJ)
+	awk -i inplace '{gsub("^PROJ :=.*$$", "PROJ := $(PROJ)", $$0); print $$0}' Makefile
 	cp Makefile ./user_projects/$(PROJ)
-	sed -i "0,/PROJ := /{s/PROJ := .*/PROJ := $(PROJ)/}" ./user_projects/$(PROJ)/Makefile
 	cp VERSION.txt ./user_projects/$(PROJ)
 	cp -r ./config/* ./user_projects/$(PROJ)/config
 	cp -r ./custom_modules/* ./user_projects/$(PROJ)/custom_modules

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -194,7 +194,7 @@ data-cleanup:
 # archival 
 	
 checkpoint: 
-	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/*.xml custom_modules/* 
+	zip -r $$(date +%b_%d_%Y_%H%M).zip Makefile *.cpp *.h config/* custom_modules/* 
 	
 zip:
 	zip -r latest.zip Makefile* *.cpp *.h BioFVM/* config/* core/* custom_modules/* matlab/* modules/* sample_projects/* 

--- a/unit_tests/substrate_internalization/Makefile-unit-test-conservation
+++ b/unit_tests/substrate_internalization/Makefile-unit-test-conservation
@@ -140,15 +140,17 @@ custom-unit-substrate-conservation.o: ./custom_modules/custom-unit-substrate-con
 # cleanup
 
 reset:
-	rm -f *.cpp 
-	cp ./sample_projects/Makefile-default Makefile 
-	rm -f ./custom_modules/*
-	touch ./custom_modules/empty.txt 
-	touch ALL_CITATIONS.txt 
-	rm ALL_CITATIONS.txt 
-	cp ./config/PhysiCell_settings_default.xml ./config/PhysiCell_settings.xml 
-	touch ./config/empty.txt
-	
+	make clean
+	rm -f *.cpp
+	cp ./sample_projects/Makefile-default Makefile
+	rm -fr ./custom_modules/*
+	touch ./custom_modules/empty.txt
+	touch ALL_CITATIONS.txt
+	rm ALL_CITATIONS.txt
+	mv ./config/PhysiCell_settings-backup.xml .
+	rm -fr ./config/*
+	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+
 clean:
 	rm -f *.o
 	rm -f $(PROGRAM_NAME)*

--- a/unit_tests/substrate_internalization/Makefile-unit-test-conservation
+++ b/unit_tests/substrate_internalization/Makefile-unit-test-conservation
@@ -147,9 +147,8 @@ reset:
 	touch ./custom_modules/empty.txt
 	touch ALL_CITATIONS.txt
 	rm ALL_CITATIONS.txt
-	mv ./config/PhysiCell_settings-backup.xml .
 	rm -fr ./config/*
-	mv PhysiCell_settings-backup.xml ./config/PhysiCell_settings.xml
+	cp ./sample_projects/PhysiCell_settings.xml-default ./config/PhysiCell_settings.xml
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
This pull request is written on top of pull request #244 and addresses issue #222 .
What the pull request solves:

**The Makefile save function now sets the PROJ variable in the Makefile to the actual name the project was saved with.**

Before when e.g. a project was saved with
```
make save PROJ=abc
```
the save project had his PROJ variable still set to
```
PROJ := my_project
```
or whatever the PROJ variable was set before.
Now the saved project will have set the PROJ variable correctely to 
```
PROJ := abc
```
as it should be.

**This is a crucial change because it will prevent users from down the road overwriting accidentally the original project from which the newly saved project was derived from.**

@rheiland, because this changes use a sed command, cloud you, please check if this works on the Windows bash shell and on MacOSX zsh shell? That would be very helpful! 