### PR TITLE
Exploring a log file to focus console output

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1609,7 +1609,7 @@ void prebuild_cell_definition_index_maps( void )
 		int ID = node.attribute( "ID" ).as_int();  
 		std::string type_name = node.attribute( "name" ).value();   
 
-		std::cout << "Pre-processing type " << ID << " named " << type_name << std::endl; 
+		log_output( "Pre-processing type " + std::to_string(ID) + " named " + type_name );
 		
 //		cell_definitions_by_name[ type_name ] = pCD; 
 //		cell_definitions_by_type[ pCD->type ] = pCD; 
@@ -1731,17 +1731,17 @@ void display_cell_definitions( std::ostream& os )
 		// summarize functions 
 		Cell_Functions* pCF = &(pCD->functions); 
 		os << "\t key functions: " << std::endl; 
-		os << "\t\t migration bias rule: "; display_ptr_as_bool( pCF->update_migration_bias , std::cout ); 
+		os << "\t\t migration bias rule: "; display_ptr_as_bool( pCF->update_migration_bias , os ); 
 		os << std::endl; 
-		os << "\t\t custom rule: "; display_ptr_as_bool( pCF->custom_cell_rule , std::cout ); 
+		os << "\t\t custom rule: "; display_ptr_as_bool( pCF->custom_cell_rule , os ); 
 		os << std::endl; 
-		os << "\t\t phenotype rule: "; display_ptr_as_bool( pCF->update_phenotype , std::cout ); 
+		os << "\t\t phenotype rule: "; display_ptr_as_bool( pCF->update_phenotype , os ); 
 		os << std::endl; 
-		os << "\t\t volume update function: "; display_ptr_as_bool( pCF->volume_update_function , std::cout ); 
+		os << "\t\t volume update function: "; display_ptr_as_bool( pCF->volume_update_function , os ); 
 		os << std::endl; 
-		os << "\t\t mechanics function: "; display_ptr_as_bool( pCF->update_velocity , std::cout ); 
+		os << "\t\t mechanics function: "; display_ptr_as_bool( pCF->update_velocity , os ); 
 		os << std::endl;
-		os << "\t\t contact function: "; display_ptr_as_bool( pCF->contact_function , std::cout ); 
+		os << "\t\t contact function: "; display_ptr_as_bool( pCF->contact_function , os ); 
 		os << std::endl; 
 		
 		// summarize motility 
@@ -1998,8 +1998,7 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 	// figure out if this ought to be 2D
 	if( default_microenvironment_options.simulate_2D )
 	{
-		std::cout << "Note: setting cell definition to 2D based on microenvironment domain settings ... "
-		<< std::endl; 
+		log_output( "Note: setting cell definition to 2D based on microenvironment domain settings ... " );
 		pCD->functions.set_orientation = up_orientation; 
 		pCD->phenotype.geometry.polarity = 1.0; 
 		pCD->phenotype.motility.restrict_to_2D = true; 
@@ -2572,7 +2571,7 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
         node_mech = node.child( "attachment_elastic_constant" );
 		if( node_mech )
 		{ pM->attachment_elastic_constant = xml_get_my_double_value( node_mech ); }
-		std::cout << "  --------- attachment_elastic_constant = " << pM->attachment_elastic_constant << std::endl;
+		log_file << "  --------- attachment_elastic_constant = " << pM->attachment_elastic_constant << std::endl;
 
         node_mech = node.child( "attachment_rate" );
 		if( node_mech )
@@ -3111,7 +3110,7 @@ void initialize_cell_definitions_from_pugixml( pugi::xml_node root )
 	
 	while( node )
 	{
-		std::cout << "Processing " << node.attribute( "name" ).value() << " ... " << std::endl; 
+		log_file << "Processing " << node.attribute( "name" ).value() << " ... " << std::endl;
 		
 		initialize_cell_definition_from_pugixml( node );	
 		build_cell_definitions_maps(); 

--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -1536,9 +1536,6 @@ void parse_csv_rules_v0( std::string filename )
 	}
 
 	fs.close(); 
-
-	std::cout << "Done!" << std::endl << std::endl; 
-
 	return; 
 }
 
@@ -1672,9 +1669,6 @@ void parse_csv_rules_v1( std::string filename )
 	}
 
 	fs.close(); 
-
-	std::cout << "Done!" << std::endl << std::endl; 
-
 	return; 
 }
 
@@ -1805,9 +1799,6 @@ void parse_csv_rules_v2( std::string filename )
 	}
 
 	fs.close(); 
-
-	std::cout << "Done!" << std::endl << std::endl; 
-
 	return; 
 }
 
@@ -1850,7 +1841,6 @@ void parse_rules_from_pugixml( void )
 
 	while( node )
 	{
-		std::cout << node.name() << std::endl;
 		if( node.attribute("enabled").as_bool() == true )
 		{ 
 			std::string folder = xml_get_string_value( node, "folder" ); 
@@ -1901,41 +1891,45 @@ void parse_rules_from_pugixml( void )
 
 			}  
 
+			log_output( "Done!\n" );
+
 
 			if( done == false )
 			{ std::cout << "\tWarning: Ruleset had unknown format (" << format << "). Skipping!" << std::endl; }
 
 		}
 		else
-		{ std::cout << "\tRuleset disabled ... " << std::endl; }
+		{
+			log_warning( "Ruleset disabled ... ", "PhysiCell_settings.xml" );
+		}
 		node = node.next_sibling( "ruleset"); 		
 	}
 	return; 
 
-	exit(0); 
+	// exit(0); 
 	
-	// enabled? 
-	if( node.attribute("enabled").as_bool() == false )
-	{ return; }
+	// // enabled? 
+	// if( node.attribute("enabled").as_bool() == false )
+	// { return; }
 
-	// get filename 
+	// // get filename 
 
-	std::string folder = xml_get_string_value( node, "folder" ); 
-	std::string filename = xml_get_string_value( node, "filename" ); 
-	std::string input_filename = folder + "/" + filename; 
+	// std::string folder = xml_get_string_value( node, "folder" ); 
+	// std::string filename = xml_get_string_value( node, "filename" ); 
+	// std::string input_filename = folder + "/" + filename; 
 
-	std::string filetype = node.attribute("type").value() ; 
+	// std::string filetype = node.attribute("type").value() ; 
 
-	// what kind? 
-	if( filetype == "csv" || filetype == "CSV" )
-	{
-		std::cout << "Loading rules from CSV file " << input_filename << " ... " << std::endl; 
-		// load_cells_csv( input_filename );
-		parse_csv_rules_v0( input_filename ); 
-		return; 
-	}
+	// // what kind? 
+	// if( filetype == "csv" || filetype == "CSV" )
+	// {
+	// 	std::cout << "Loading rules from CSV file " << input_filename << " ... " << std::endl; 
+	// 	// load_cells_csv( input_filename );
+	// 	parse_csv_rules_v0( input_filename ); 
+	// 	return; 
+	// }
 
-	return; 
+	// return; 
 }
 
 void parse_rules_from_parameters_v0( void )
@@ -2098,7 +2092,7 @@ void export_rules_csv_v0( std::string filename )
 		return; 
 	}
 
-	std::cout << "Exporting rules to file " << filename << " (v0 format) ... " << std::endl; 
+	log_output( "Exporting rules to file " + filename + " (v0 format) ... " );
 
 	for( int n=0; n < cell_definitions_by_index.size(); n++ )
 	{
@@ -2145,9 +2139,6 @@ void export_rules_csv_v0( std::string filename )
  Cell type, behavior, min value, base value, max value,   signal, direction, half-max, Hill power, dead
 */ 
 	fs.close(); 
-
-	std::cout << "Done!" << std::endl << std::endl; 
-
 	return; 
 }
 
@@ -2162,7 +2153,7 @@ void export_rules_csv_v1( std::string filename )
 		return; 
 	}
 
-	std::cout << "Exporting rules to file " << filename << " (v1 format) ... " << std::endl; 
+	log_output( "Exporting rules to file " + filename + " (v1 format) ... " );
 
 	for( int n=0; n < cell_definitions_by_index.size(); n++ )
 	{
@@ -2203,9 +2194,6 @@ void export_rules_csv_v1( std::string filename )
  Cell type, signal, direcxtion, behavior, base, max_response, half-max, hill , dead 
 */ 
 	fs.close(); 
-
-	std::cout << "Done!" << std::endl << std::endl; 
-
 	return; 
 }
 
@@ -2218,7 +2206,7 @@ void export_rules_csv_v2( std::string filename )
 		return; 
 	}
 
-	std::cout << "Exporting rules to file " << filename << " (v2 format) ... " << std::endl; 
+	log_output( "Exporting rules to file " + filename + " (v2 format) ... " );
 
 	for( int n=0; n < cell_definitions_by_index.size(); n++ )
 	{
@@ -2260,9 +2248,6 @@ void export_rules_csv_v2( std::string filename )
  Cell type, signal, direcxtion, behavior, base, max_response, half-max, hill , dead 
 */ 
 	fs.close(); 
-
-	std::cout << "Done!" << std::endl << std::endl; 
-
 	return; 
 }
 
@@ -2348,7 +2333,7 @@ void setup_cell_rules( void )
 	parse_rules_from_pugixml(); 
 
 	// display rules to screen
-	display_hypothesis_rulesets( std::cout );
+	display_hypothesis_rulesets( log_file );
 
 	// save annotations 
 	save_annotated_detailed_English_rules(); 
@@ -2367,7 +2352,7 @@ void setup_cell_rules( void )
 	// save rules (v1)
 	std::string rules_file = PhysiCell_settings.folder + "/cell_rules.csv"; 
 	export_rules_csv_v1( rules_file ); 
-
+	log_output("Done!\n");
 
 	return; 
 }

--- a/core/PhysiCell_signal_behavior.cpp
+++ b/core/PhysiCell_signal_behavior.cpp
@@ -542,8 +542,8 @@ void setup_signal_behavior_dictionaries( void )
     // resize scales; 
     signal_scales.resize( int_to_signal.size() , 1.0 ); 
 
-    display_signal_dictionary(); 
-    display_behavior_dictionary(); 
+    display_signal_dictionary( log_file ); 
+    display_behavior_dictionary( log_file ); 
 /*
 	// now create empty SR models for each cell definition 
 

--- a/modules/PhysiCell_geometry.cpp
+++ b/modules/PhysiCell_geometry.cpp
@@ -787,7 +787,6 @@ void load_cells_csv_v2( std::string filename )
 	// close the file 
 
 	file.close(); 
-	std::cout << "Done! " << std::endl << std::endl; 
 
 	return; 
 }

--- a/modules/PhysiCell_log.cpp
+++ b/modules/PhysiCell_log.cpp
@@ -1,0 +1,78 @@
+#include "PhysiCell_log.h"
+
+namespace PhysiCell
+{
+    std::ofstream log_file;
+
+    void open_log_file(std::string filename)
+    {
+        log_file.open(filename.c_str());
+        return;
+    }
+
+    void close_log_file(void)
+    {
+        log_file.close();
+        return;
+    }
+
+    void flush_log_file(void)
+    {
+        log_file.flush();
+        return;
+    }
+
+    void log_output(std::string message, bool also_write_to_cout, bool add_newline_at_end)
+    {
+        log_file << message;
+        if (add_newline_at_end)
+        {
+            log_file << std::endl;
+        }
+        if (also_write_to_cout)
+        {
+            std::cout << message << std::endl;
+        }
+        return;
+    }
+
+    void log_output(std::ostream &(*f)(std::ostream &), bool also_write_to_cout, bool add_newline_at_end)
+    {
+        log_file << f;
+        if (add_newline_at_end)
+        {
+            log_file << std::endl;
+        }
+        if (also_write_to_cout)
+        {
+            std::cout << f << std::endl;
+        }
+        return;
+    }
+
+    void log_warning(std::string message, std::string filename)
+    {
+        log_file << "Warning: " << message;
+        std::cout << "\nWARNING: " << message;
+        if (filename != "")
+        {
+            log_file << " (in " << filename << ")" << std::endl;
+            std::cout << " (in " << filename << ")\n" << std::endl;
+        }
+        return;
+    }
+
+    void log_error(std::string message, std::string filename)
+    {
+        log_file << "Error: " << message;
+        std::cout << "ERROR: " << message;
+        if (filename != "")
+        {
+            log_file << " (in " << filename << ")" << std::endl;
+            std::cout << " (in " << filename << ")" << std::endl;
+        }
+        close_log_file();
+        exit(-1);
+        return;
+    }
+}

--- a/modules/PhysiCell_log.h
+++ b/modules/PhysiCell_log.h
@@ -1,0 +1,15 @@
+#include <fstream>
+#include <iostream>
+
+namespace PhysiCell
+{
+    extern std::ofstream log_file;
+
+    void open_log_file(std::string filename);
+    void close_log_file(void);
+    void flush_log_file(void);
+    void log_output(std::string message, bool also_write_to_cout = false, bool add_newline_at_end = true);
+    void log_output(std::ostream &(*f)(std::ostream &), bool also_write_to_cout = false, bool add_newline_at_end = true);
+    void log_warning(std::string message, std::string filename = "");
+    void log_error(std::string message, std::string filename = "");
+}

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -77,7 +77,7 @@ User_Parameters parameters;
 bool physicell_config_dom_initialized = false; 
 pugi::xml_document physicell_config_doc; 	
 pugi::xml_node physicell_config_root; 
-	
+
 bool load_PhysiCell_config_file( std::string filename )
 {
 	std::cout << "Using config file " << filename << " ... " << std::endl ; 

--- a/modules/PhysiCell_standard_modules.h
+++ b/modules/PhysiCell_standard_modules.h
@@ -81,4 +81,6 @@
 
 #include "./PhysiCell_geometry.h" 
 
+#include "./PhysiCell_log.h"
+
 #endif

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -54,7 +54,7 @@ PhysiCell_cell.o PhysiCell_custom.o PhysiCell_utilities.o PhysiCell_constants.o 
 PhysiCell_signal_behavior.o PhysiCell_rules.o
 
 PhysiCell_module_OBJECTS := PhysiCell_SVG.o PhysiCell_pathology.o PhysiCell_MultiCellDS.o PhysiCell_various_outputs.o \
-PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o
+PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o PhysiCell_log.o
 
 PhysiMeSS_OBJECTS := PhysiMeSS.o PhysiMeSS_agent.o PhysiMeSS_fibre.o PhysiMeSS_cell.o
 
@@ -167,6 +167,9 @@ PhysiCell_basic_signaling.o: ./core/PhysiCell_basic_signaling.cpp
 	
 PhysiCell_geometry.o: ./modules/PhysiCell_geometry.cpp
 	$(COMPILE_COMMAND) -c ./modules/PhysiCell_geometry.cpp 
+
+PhysiCell_log.o: ./modules/PhysiCell_log.cpp
+	$(COMPILE_COMMAND) -c ./modules/PhysiCell_log.cpp 
 	
 # PhysiMeSS
 PhysiMeSS.o: ./addons/PhysiMeSS/PhysiMeSS.cpp 

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -54,7 +54,7 @@ PhysiCell_cell.o PhysiCell_custom.o PhysiCell_utilities.o PhysiCell_constants.o 
 PhysiCell_signal_behavior.o PhysiCell_rules.o
 
 PhysiCell_module_OBJECTS := PhysiCell_SVG.o PhysiCell_pathology.o PhysiCell_MultiCellDS.o PhysiCell_various_outputs.o \
-PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o
+PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o PhysiCell_log.o
 
 # put your custom objects here (they should be in the custom_modules directory)
 
@@ -165,6 +165,9 @@ PhysiCell_basic_signaling.o: ./core/PhysiCell_basic_signaling.cpp
 	
 PhysiCell_geometry.o: ./modules/PhysiCell_geometry.cpp
 	$(COMPILE_COMMAND) -c ./modules/PhysiCell_geometry.cpp 
+	
+PhysiCell_log.o: ./modules/PhysiCell_log.cpp
+	$(COMPILE_COMMAND) -c ./modules/PhysiCell_log.cpp 
 	
 # user-defined PhysiCell modules
 

--- a/sample_projects/template/custom_modules/custom.cpp
+++ b/sample_projects/template/custom_modules/custom.cpp
@@ -131,7 +131,7 @@ void create_cell_types( void )
 	   This builds the map of cell definitions and summarizes the setup. 
 	*/
 		
-	display_cell_definitions( std::cout ); 
+	display_cell_definitions( log_file ); 
 	
 	return; 
 }

--- a/sample_projects/template/main.cpp
+++ b/sample_projects/template/main.cpp
@@ -101,6 +101,10 @@ int main( int argc, char* argv[] )
 	}
 	if( !XML_status )
 	{ exit(-1); }
+
+	// set up a file called output.log to record the output from the program
+	std::string output_log_filename = PhysiCell_settings.folder + "/output.log";
+	open_log_file(output_log_filename);
 	
 	// copy config file to output directry 
 	system( copy_command ); 
@@ -183,7 +187,7 @@ int main( int argc, char* argv[] )
 			// save data if it's time. 
 			if( fabs( PhysiCell_globals.current_time - PhysiCell_globals.next_full_save_time ) < 0.01 * diffusion_dt )
 			{
-				display_simulation_status( std::cout ); 
+				display_simulation_status( log_file ); 
 				if( PhysiCell_settings.enable_legacy_saves == true )
 				{	
 					log_output( PhysiCell_globals.current_time , PhysiCell_globals.full_output_index, microenvironment, report_file);
@@ -250,5 +254,6 @@ int main( int argc, char* argv[] )
 	std::cout << std::endl << "Total simulation runtime: " << std::endl; 
 	BioFVM::display_stopwatch_value( std::cout , BioFVM::runtime_stopwatch_value() ); 
 
+	close_log_file();
 	return 0; 
 }

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -54,7 +54,7 @@ PhysiCell_cell.o PhysiCell_custom.o PhysiCell_utilities.o PhysiCell_constants.o 
 PhysiCell_signal_behavior.o PhysiCell_rules.o PhysiCell_basic_signaling.o
 
 PhysiCell_module_OBJECTS := PhysiCell_SVG.o PhysiCell_pathology.o PhysiCell_MultiCellDS.o PhysiCell_various_outputs.o \
-PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o 
+PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o PhysiCell_log.o
 
 # put your custom objects here (they should be in the custom_modules directory)
 
@@ -166,6 +166,9 @@ PhysiCell_basic_signaling.o: ./core/PhysiCell_basic_signaling.cpp
 PhysiCell_geometry.o: ./modules/PhysiCell_geometry.cpp
 	$(COMPILE_COMMAND) -c ./modules/PhysiCell_geometry.cpp 
 	
+PhysiCell_log.o: ./modules/PhysiCell_log.cpp
+	$(COMPILE_COMMAND) -c ./modules/PhysiCell_log.cpp 
+
 # user-defined PhysiCell modules
 
 custom.o: ./custom_modules/custom.cpp 

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -78,7 +78,7 @@ PhysiCell_cell.o PhysiCell_custom.o PhysiCell_utilities.o PhysiCell_constants.o 
 PhysiCell_signal_behavior.o PhysiCell_rules.o
 
 PhysiCell_module_OBJECTS := PhysiCell_SVG.o PhysiCell_pathology.o PhysiCell_MultiCellDS.o PhysiCell_various_outputs.o \
-PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o
+PhysiCell_pugixml.o PhysiCell_settings.o PhysiCell_geometry.o PhysiCell_log.o
 
 # put your custom objects here (they should be in the custom_modules directory)  
 MaBoSS := ./addons/PhysiBoSS/MaBoSS-env-2.0/engine/src/BooleanNetwork.h
@@ -192,6 +192,9 @@ PhysiCell_basic_signaling.o: ./core/PhysiCell_basic_signaling.cpp
 	
 PhysiCell_geometry.o: ./modules/PhysiCell_geometry.cpp
 	$(COMPILE_COMMAND) -c ./modules/PhysiCell_geometry.cpp 
+	
+PhysiCell_log.o: ./modules/PhysiCell_log.cpp
+	$(COMPILE_COMMAND) -c ./modules/PhysiCell_log.cpp 
 
 # user-defined PhysiCell modules
 


### PR DESCRIPTION
**This PR needs feedback before merge**

I know I do not pay attention to the console output at startup mostly because it goes by so fast. I barely know what shows up there (Did you know it prints "rulesets" every time it finds a `rulesets` element?). Warnings are instantly lost and not received by the user. Rulesets not enabled? You'll never know until you check the results. The console scrollback buffer can also be quickly exceeded and lose some of that opening info.

So, I am looking to have a conversation around creating a log file that puts some/most of this info into a log file to allow the user to focus on more critical output. I started with this PR that aggressively swings the pendulum the other way to show what's possible. Hopefully, with feedback, we can find a nice equilibrium.

### Some notes of this implementation
1. this only logs PhysiCell output, not BioFVM (namespace concerns, particularly at startup)
2. create a standard way to write a PhysiCell warning/error (`log_warning` and `log_error` functions)
3. an optional variable to `log_output` allows the message to also be printed to `std::cout` so it is easy for devs to have both!
4. `log_warning` and `log_error` default to printing to console
5. I don't know how to easily (read: in one line) convert some of the syntax for `log_output(std::string message)` function signature. Specifically, something like `std::cout << a_string_var << " and " << a_char_var << std::endl;` so I converted these to `log_file << a_string_var << " and " << a_char_var << std::endl;` which works but creates inconsistencies
6. Test it on the template project or else **update your Makefile**