### PR TITLE
handle duplicate density and parameter

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -474,8 +474,15 @@ void Microenvironment::resize_densities( int new_size )
 void Microenvironment::add_density( void )
 {
 	// fix in PhysiCell preview November 2017 
-	// default_microenvironment_options.use_oxygen_as_first_field = false; 
-	
+	// default_microenvironment_options.use_oxygen_as_first_field = false;
+
+	// check if density exist
+	if (find_density_index( "unnamed" ) != -1)
+	{
+		std::cout << "Error: density unnamed already exists!" << std::endl;
+		exit(-1);
+	}
+
 	// update 1, 0 
 	zero.push_back( 0.0 ); 
 	one.push_back( 1.0 );
@@ -545,8 +552,15 @@ void Microenvironment::add_density( void )
 void Microenvironment::add_density( std::string name , std::string units )
 {
 	// fix in PhysiCell preview November 2017 
-	// default_microenvironment_options.use_oxygen_as_first_field = false; 
-	
+	// default_microenvironment_options.use_oxygen_as_first_field = false;
+
+	// check if density exist
+	if (find_density_index( name ) != -1)
+	{
+		std::cout << "Error: density named " << name << " already exists!" << std::endl;
+		exit(-1);
+	}
+
 	// update 1, 0 
 	zero.push_back( 0.0 ); 
 	one.push_back( 1.0 );
@@ -614,8 +628,15 @@ void Microenvironment::add_density( std::string name , std::string units )
 void Microenvironment::add_density( std::string name , std::string units, double diffusion_constant, double decay_rate )
 {
 	// fix in PhysiCell preview November 2017 
-	// default_microenvironment_options.use_oxygen_as_first_field = false; 
-	
+	// default_microenvironment_options.use_oxygen_as_first_field = false;
+
+	// check if density exist
+	if (find_density_index( name ) != -1)
+	{
+		std::cout << "Error: density named " << name << " already exists!" << std::endl;
+		exit(-1);
+	}
+
 	// update 1, 0 
 	zero.push_back( 0.0 ); 
 	one.push_back( 1.0 );
@@ -679,6 +700,39 @@ void Microenvironment::add_density( std::string name , std::string units, double
 	default_microenvironment_options.Dirichlet_zmax_values.push_back( 1.0 ); 	
 
 	return; 
+}
+
+void Microenvironment::update_density( std::string name , std::string units )
+{
+	// density exist?
+	int density_index = find_density_index( name );
+	if ( density_index == -1 )
+	{
+		// add density
+		return Microenvironment::add_density( name , units );
+	}
+
+	// update units
+	density_units[density_index] = units;
+	return;
+}
+
+void Microenvironment::update_density( std::string name , std::string units, double diffusion_constant, double decay_rate )
+{
+	// density exist?
+	int density_index = find_density_index( name );
+	if ( density_index == -1 )
+	{
+		// add density
+		return Microenvironment::add_density( name , units, diffusion_constant, decay_rate );
+	}
+
+	// update units
+	density_units[density_index] = units;
+	// update coefficients
+	diffusion_coefficients[density_index] = diffusion_constant;
+	decay_rates[density_index] = decay_rate;
+	return;
 }
 
 int Microenvironment::find_density_index( std::string name )

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -186,6 +186,9 @@ class Microenvironment
 	void add_density( std::string name , std::string units );
 	void add_density( std::string name , std::string units, double diffusion_constant, double decay_rate ); 
 
+	void update_density( std::string name , std::string units );
+	void update_density( std::string name , std::string units, double diffusion_constant, double decay_rate );
+
 	void set_density( int index , std::string name , std::string units ); 
 	void set_density( int index , std::string name , std::string units , double diffusion_constant , double decay_rate ); 
 

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -453,7 +453,7 @@ void Parameters<T>::add_parameter( std::string my_name )
 	int parameter_index = -1;
 	auto it = name_to_index_map.find(my_name);
 
-	if (it == name_to_index_map.end())
+	if (it != name_to_index_map.end())
 	{
 		std::cout << "Error: parameter named " << my_name << " already exists!" << std::endl;
 		exit(-1);
@@ -478,7 +478,7 @@ void Parameters<T>::add_parameter( std::string my_name , T my_value )
 	int parameter_index = -1;
 	auto it = name_to_index_map.find(my_name);
 
-	if (it == name_to_index_map.end())
+	if (it != name_to_index_map.end())
 	{
 		std::cout << "Error: parameter named " << my_name << " already exists!" << std::endl;
 		exit(-1);
@@ -504,7 +504,7 @@ void Parameters<T>::add_parameter( std::string my_name , T my_value , std::strin
 	int parameter_index = -1;
 	auto it = name_to_index_map.find(my_name);
 
-	if (it == name_to_index_map.end())
+	if (it != name_to_index_map.end())
 	{
 		std::cout << "Error: parameter named " << my_name << " already exists!" << std::endl;
 		exit(-1);

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -89,7 +89,7 @@ namespace PhysiCell{
  	
 extern pugi::xml_node physicell_config_root; 
 
-bool load_PhysiCell_config_file( std::string filename );
+bool load_PhysiCell_config_file( std::string filename, bool update_variables = false );
 
 class PhysiCell_Settings
 {
@@ -183,15 +183,16 @@ class Parameters
 	Parameters(); 
  
 	std::vector< Parameter<T> > parameters; 
-	
-	void add_parameter( std::string my_name ); 
-	void add_parameter( std::string my_name , T my_value ); 
-//	void add_parameter( std::string my_name , T my_value ); 
-	void add_parameter( std::string my_name , T my_value , std::string my_units ); 
-//	void add_parameter( std::string my_name , T my_value , std::string my_units ); 
-	
+
+	void add_parameter( std::string my_name );
+	void add_parameter( std::string my_name , T my_value );
+	void add_parameter( std::string my_name , T my_value , std::string my_units );
 	void add_parameter( Parameter<T> param );
-	
+
+	void update_parameter( std::string my_name , T my_value );
+	void update_parameter( std::string my_name , T my_value , std::string my_units );
+	void update_parameter( Parameter<T> param );
+
 	int find_index( std::string search_name ); 
 	
 	// these access the values 
@@ -215,8 +216,8 @@ class User_Parameters
 	Parameters<int> ints; 
 	Parameters<double> doubles; 
 	Parameters<std::string> strings; 
-	
-	void read_from_pugixml( pugi::xml_node parent_node );
+
+	void read_from_pugixml( pugi::xml_node parent_node, bool update_parameter = false );
 }; 
 
 extern PhysiCell_Globals PhysiCell_globals; 
@@ -225,8 +226,8 @@ extern PhysiCell_Settings PhysiCell_settings;
 
 extern User_Parameters parameters; 
 
-bool setup_microenvironment_from_XML( pugi::xml_node root_node );
-bool setup_microenvironment_from_XML( void );
+bool setup_microenvironment_from_XML( pugi::xml_node root_node, bool update_density = false );
+bool setup_microenvironment_from_XML( bool update_density = false );
 
 }
 


### PR DESCRIPTION
pull request for the staled pull request #250 and #232

this pull request keeps the changes to the existing code bases as small as possible.
default settings were chosen so that the current models not will break through these changes.
each case was manually tested, the code works as expected. 

add_density and add_parameter functions:
+ Microenvironment::**add_density**: throw error, if a density with the same name already exists.
+ Parameters::**add_parameter** :  throw error, if a parameter with the same name and type already exists.

update_density and update_parameter functions:
+ Microenvironment::**update_density** : new function which does not throw an error but updates the values, if a density with the same name already exists.
+ Parameters::**update_parameter** :  new function which does not throw an error but updates the values, if a parameter with the same name and type already exists.

function calls arguments:
+ **load_PhysiCell_config_file**: additional bool update_variables argument with default set to false.
+ **setup_microenvironment_from_XML** (called from load_PhysiCell_config_file):  additional bool update_density argument with default set to false. 
+ User_Parameters::**read_from_pugixml** (called from load_PhysiCell_config_file): additional bool update_parameter argument with default set to false.

