### PR TITLE
Removing a duplicated parameter which was in one of PhysiMeSS examples

### DIFF
--- a/sample_projects/physimess/config/Fibre_Degradation/mymodel_matrix_degradation.xml
+++ b/sample_projects/physimess/config/Fibre_Degradation/mymodel_matrix_degradation.xml
@@ -289,7 +289,6 @@
         <fibre_stuck_time type="double" units="1/min" description="time before stuck cell can degrade fibre">10000.0</fibre_stuck_time>
         <fibre_stuck_threshold type="double" units="none" description="movement threshold to declare a cell stuck">0.05</fibre_stuck_threshold>
         <fibre_pressure_threshold type="double" units="1/min" description="time before stuck cell can degrade fibre">10.0</fibre_pressure_threshold>
-        <color_cells_by_pressure type="bool" units="" description="flag for coloring cells by pressure">false</color_cells_by_pressure>
         
         <fibre_pushing type="bool" units="none" description="flag for fibre pushing">false</fibre_pushing>
         <fibre_sticky type="double" units="none" description="measure of how easy it is to move a fibre">1.0</fibre_sticky>


### PR DESCRIPTION
Removing a duplicated parameter which was in one of PhysiMeSS examples