### PR TITLE
Fix random seed warning message

### DIFF
--- a/core/PhysiCell_utilities.cpp
+++ b/core/PhysiCell_utilities.cpp
@@ -85,11 +85,10 @@ void setup_rng( void )
 	if (!warned && setup_done)
 	{
 		std::cout << "WARNING: Setting the random seed again." << std::endl
-				  << "\tYou probably have..." << std::endl
-				  << "\t\t1. added a random seed element to options in the config file AND" << std::endl
-				  << "\t\t2. set a user parameter called random seed." << std::endl
+				  << "\tYou probably have set a user parameter called random_seed." << std::endl
+				  << "\tHere, we will use the random seed set in user parameters." << std::endl	
+				  << "\tHOWEVER, as of PhysiCell 1.14.0, you should set the random seed in the <options><random_seed> element in the config file." << std::endl
 				  << "\tFuture versions of PhysiCell may throw an error here. Kindly remove the user parameter and just use the <options><random_seed> element." << std::endl;
-		// exit(-1);
 		warned = true;
 	}
 	std::cout << "Setting up RNG with seed " << physicell_random_seed << std::endl;


### PR DESCRIPTION
I want to still default to using the system clock, which means doing that even if it's not set in the options. This will give a more actionable error than if a user removes BOTH the options element and the user parameter.