### PR TITLE
Fix bug in matlab/read_MultiCellDS_xml.m

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.asv
 ._.DS_Store
 .DS_Store
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ name:
 list-projects:
 	@echo "Sample projects: template biorobots-sample cancer-biorobots-sample cancer-immune-sample"
 	@echo "                 celltypes3-sample heterogeneity-sample pred-prey-farmer virus-macrophage-sample"
-	@echo "                 worm-sample interaction-sample mechano-sample rules-sample physimess-sample"
+	@echo "                 worm-sample interaction-sample mechano-sample rules-sample physimess-sample custom-division-sample"
 	@echo ""
 	@echo "Sample intracellular projects: template_BM ode-energy-sample physiboss-cell-lines-sample"
 	@echo "                 cancer-metabolism-sample physiboss-tutorial physiboss-tutorial-invasion"
@@ -196,6 +196,16 @@ physimess-sample:
 	cp ./sample_projects/physimess/Makefile .
 	cp ./config/PhysiCell_settings.xml ./config/PhysiCell_settings-backup.xml 
 	cp -r ./sample_projects/physimess/config/* ./config/
+
+
+custom-division-sample:
+	cp ./sample_projects/custom_division/custom_modules/* ./custom_modules/
+	touch main.cpp && cp main.cpp main-backup.cpp
+	cp ./sample_projects/custom_division/main.cpp ./main.cpp 
+	cp Makefile Makefile-backup
+	cp ./sample_projects/custom_division/Makefile .
+	cp ./config/PhysiCell_settings.xml ./config/PhysiCell_settings-backup.xml 
+	cp ./sample_projects/custom_division/config/* ./config/
 
 # ---- intracellular projects 
 ode-energy-sample:

--- a/matlab/read_MultiCellDS_xml.m
+++ b/matlab/read_MultiCellDS_xml.m
@@ -63,24 +63,24 @@
 %                                                                             %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-% Usage: 
+% Usage:
 %
-% MCDS = read_MultiCellDS_xml( filename ) OR 
+% MCDS = read_MultiCellDS_xml( filename ) OR
 %
 % MCDS = read_MultiCellDS_xml( filename , directory )
 %
 % MCDS.metadata has key metadata information
 %
-% MCDS.mesh has the mesh, including: 
+% MCDS.mesh has the mesh, including:
 %           X_coordinates, Y_coordinates, Z_coordinates
 %           and a meshgrid [X,Y,Z]
 %
-% MCDS.continuum_variables has densities. 
-%           Access MCDS.continuum_variables(1), etc. 
+% MCDS.continuum_variables has densities.
+%           Access MCDS.continuum_variables(1), etc.
 %
-% MCDS.discrete_cells has individual cells 
-%           Access MCDS.discrete_cells.phenotype. etc. to get to arrays 
-%               of cell phenotype properties. e.g., 
+% MCDS.discrete_cells has individual cells
+%           Access MCDS.discrete_cells.phenotype. etc. to get to arrays
+%               of cell phenotype properties. e.g.,
 %
 % MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume(i)
 %
@@ -90,382 +90,375 @@
 % Licensed under 3-Clause BSD
 %
 
-function MCDS = read_MultiCellDS_xml( filename , directory )
-tic; 
+function MCDS = read_MultiCellDS_xml_vdb( filename , directory )
+tic;
 
 if( nargin == 1 )
-    directory = '.'; 
+    directory = '.';
 end
 
-MCDS_constants = set_MCDS_constants(); 
+MCDS.constants = set_MCDS_constants();
 
-inputfile = sprintf('%s/%s', directory , filename); 
+inputfile = sprintf('%s/%s', directory , filename);
 
-tree = xmlread( inputfile ); 
+tree = xmlread( inputfile );
 node = tree.getFirstChild(); %   MultiCellDS
 
-node = node.getElementsByTagName('microenvironment').item(0); 
-node = node.getParentNode; 
+MCDS = locfn__read_microenvironment( MCDS, node, directory );
+MCDS = locfn__read_cellular_information( MCDS, node, directory );
+
+toc
+
+%
+
+ fprintf('\nSummary for file %s:\n' , inputfile ) ;
+ fprintf('Voxels: %u\n', length(MCDS.mesh.voxels) ) 
+ fprintf('Substrates: %u\n' , length( MCDS.continuum_variables ) ) ;
+str = sprintf( '  %s (%s)' , MCDS.continuum_variables(1).name , MCDS.continuum_variables(1).units );
+for i=2:length( MCDS.continuum_variables )
+    str = sprintf( '%s, %s (%s)' , str, MCDS.continuum_variables(i).name , MCDS.continuum_variables(i).units );
+end
+disp(str);
+if( ~isempty( MCDS.discrete_cells ) )
+     fprintf('Cells: %u\n' , size( MCDS.discrete_cells.state.position , 1) ) ;
+else
+    disp( 'Cells: 0' );
+end
+
+end
+
+%% Local functions
+
+function MCDS = locfn__read_microenvironment( MCDS, multicell_ds_node, directory )
+
+node = multicell_ds_node.getElementsByTagName('microenvironment').item(0);
+node = node.getParentNode;
 
 % some key metadata
-metadata_node = node.getParentNode.getElementsByTagName('metadata').item(0); 
-node1 = metadata_node.getElementsByTagName( 'current_time' ).item(0); 
-MCDS.metadata.current_time = str2num( node1.getTextContent ); 
-MCDS.metadata.time_units = char( node1.getAttribute( 'units' ) ); 
+metadata_node = node.getParentNode.getElementsByTagName('metadata').item(0);
+node1 = metadata_node.getElementsByTagName( 'current_time' ).item(0);
+MCDS.metadata.current_time = str2double( node1.getTextContent );
+MCDS.metadata.time_units = char( node1.getAttribute( 'units' ) );
 
-node1 = metadata_node.getElementsByTagName( 'current_runtime' ).item(0); 
-MCDS.metadata.current_runtime = str2num( node1.getTextContent ); 
-MCDS.metadata.runtime_units = char( node1.getAttribute( 'units' ) ); 
+node1 = metadata_node.getElementsByTagName( 'current_runtime' ).item(0);
+MCDS.metadata.current_runtime = str2double( node1.getTextContent );
+MCDS.metadata.runtime_units = char( node1.getAttribute( 'units' ) );
 
-MCDS.metadata.spatial_units = []; 
+MCDS.metadata.spatial_units = [];
 
-% mylist = node.getElementsByTagName('microenvironment');
 microenvironment_node = node.getElementsByTagName('microenvironment').item(0);
 
-node = microenvironment_node.getElementsByTagName( 'mesh' ).item(0); % mesh level 
-MCDS.metadata.spatial_units = char( node.getAttribute( 'units' ) );  
+node = microenvironment_node.getElementsByTagName( 'mesh' ).item(0); % mesh level
+MCDS.metadata.spatial_units = char( node.getAttribute( 'units' ) );
 
-% first, read the mesh 
+% first, read the mesh
 
-meshtype = node.getAttribute( 'type' ); 
-Cartesian = false; 
+meshtype = node.getAttribute( 'type' );
+Cartesian = false;
 
-MCDS.mesh.X_coordinates = []; 
-MCDS.mesh.Y_coordinates = []; 
-MCDS.mesh.Z_coordinates = []; 
+MCDS.mesh.X_coordinates = [];
+MCDS.mesh.Y_coordinates = [];
+MCDS.mesh.Z_coordinates = [];
 
 if( strcmp( meshtype, 'Cartesian' ) )
-    str = node.getElementsByTagName( 'x_coordinates' ).item(0).getTextContent; 
-    MCDS.mesh.X_coordinates = str2num( str ); 
+    str = node.getElementsByTagName( 'x_coordinates' ).item(0).getTextContent;
+    MCDS.mesh.X_coordinates = str2num( str ); %#ok<ST2NM> str is vector of doubles
 
-    str = node.getElementsByTagName( 'y_coordinates' ).item(0).getTextContent; 
-    MCDS.mesh.Y_coordinates = str2num( str ); 
+    str = node.getElementsByTagName( 'y_coordinates' ).item(0).getTextContent;
+    MCDS.mesh.Y_coordinates = str2num( str );
 
-    str = node.getElementsByTagName( 'z_coordinates' ).item(0).getTextContent; 
-    MCDS.mesh.Z_coordinates = str2num( str ); 
-    
-    Cartesian = true; 
+    str = node.getElementsByTagName( 'z_coordinates' ).item(0).getTextContent;
+    MCDS.mesh.Z_coordinates = str2num( str ); %#ok<ST2NM> str is vector of doubles
+
+    Cartesian = true;
 end
 
-blank_voxel = []; 
+blank_voxel = [];
 blank_voxel.center = [0 0 0];
-blank_voxel.volume = 0; 
+blank_voxel.volume = 0;
 
-MCDS.mesh.voxels = []; 
+MCDS.mesh.voxels = [];
 
-voxeltype = node.getElementsByTagName( 'voxels' ).item(0).getAttribute( 'type' ); 
+voxeltype = node.getElementsByTagName( 'voxels' ).item(0).getAttribute( 'type' );
 
-if( strcmp( voxeltype , 'xml' ) )  
+if( strcmp( voxeltype , 'xml' ) )
     % if voxels stored in the XML
-    mylist = node.getElementsByTagName( 'voxel' ); 
+    voxel_tags = node.getElementsByTagName( 'voxel' );
 
-    numvoxels = mylist.getLength; 
-    MCDS.mesh.voxels = repmat( blank_voxel , 1 , numvoxels ); 
-   
-    for i=0:mylist.getLength - 1
-        MCDS.mesh.voxels(i+1).center = str2num( mylist.item(i).getElementsByTagName( 'center' ).item(0).getTextContent );
-        MCDS.mesh.voxels(i+1).volume = str2num( mylist.item(i).getElementsByTagName( 'volume' ).item(0).getTextContent );   
+    numvoxels = voxel_tags.getLength;
+    MCDS.mesh.voxels = repmat( blank_voxel , 1 , numvoxels );
+
+    for i=0:voxel_tags.getLength - 1
+        MCDS.mesh.voxels(i+1).center = str2double( voxel_tags.item(i).getElementsByTagName( 'center' ).item(0).getTextContent );
+        MCDS.mesh.voxels(i+1).volume = str2double( voxel_tags.item(i).getElementsByTagName( 'volume' ).item(0).getTextContent );
     end
 else
-    % voxels are stored in a mat file 
-    filename = node.getElementsByTagName('voxels' ).item(0).getElementsByTagName( 'filename' ).item(0).getTextContent ; 
-    %MAT = struct2array( load( char(filename) ) ); 
-    
-    filename = sprintf( '%s/%s', directory , char(filename));   
-    MAT = load(filename); % load(char(filename)); 
-    MAT = MAT.mesh; % use this instead of struct2array for better octave compatibility 
-    [m,numvoxels] = size(MAT); 
+    % voxels are stored in a mat file
+    filename = node.getElementsByTagName('voxels' ).item(0).getElementsByTagName( 'filename' ).item(0).getTextContent ;
+    %MAT = struct2array( load( char(filename) ) );
 
-    MCDS.mesh.voxels = repmat( blank_voxel , 1 , numvoxels ); 
-    
+    filename = sprintf( '%s/%s', directory , char(filename));
+    MAT = load(filename); % load(char(filename));
+    MAT = MAT.mesh; % use this instead of struct2array for better octave compatibility
+    numvoxels = size(MAT, 2);
+
+    MCDS.mesh.voxels = repmat( blank_voxel , 1 , numvoxels );
+
     for i=1:numvoxels
-        MCDS.mesh.voxels(i).center = MAT(1:3,i)'; 
-        MCDS.mesh.voxels(i).volume = MAT(4,i); 
+        MCDS.mesh.voxels(i).center = MAT(1:3,i)';
+        MCDS.mesh.voxels(i).volume = MAT(4,i);
     end
-    clear MAT; 
 end
 
-% meshgrid 
-[MCDS.mesh.X , MCDS.mesh.Y , MCDS.mesh.Z] = meshgrid( MCDS.mesh.X_coordinates , MCDS.mesh.Y_coordinates , MCDS.mesh.Z_coordinates ); 
+% meshgrid
+[MCDS.mesh.X , MCDS.mesh.Y , MCDS.mesh.Z] = meshgrid( MCDS.mesh.X_coordinates , MCDS.mesh.Y_coordinates , MCDS.mesh.Z_coordinates );
 
-% now, read the various densities 
+% now, read the various densities
 node = node.getParentNode;
-node = node.getElementsByTagName( 'variables' ).item(0); 
+node = node.getElementsByTagName( 'variables' ).item(0);
 
-mylist = node.getElementsByTagName( 'variable' ); 
+variable_tags = node.getElementsByTagName( 'variable' );
 
-MCDS.continuum_variables = []; 
+MCDS.continuum_variables = [];
 
-for i=0:mylist.getLength - 1
-   MCDS.continuum_variables(i+1).name = char( mylist.item(i).getAttribute('name' ) ); 
-   MCDS.continuum_variables(i+1).units = char( mylist.item(i).getAttribute('units' ) ); 
-   MCDS.continuum_variables(i+1).diffusion_coefficient = str2num( mylist.item(i).getElementsByTagName( 'diffusion_coefficient' ).item(0).getTextContent ); 
-   MCDS.continuum_variables(i+1).decay_rate = str2num( mylist.item(i).getElementsByTagName( 'decay_rate' ).item(0).getTextContent ); 
-   
-   if( Cartesian )
-       MCDS.continuum_variables(i+1).data = zeros( size(MCDS.mesh.X) ); % only for Cartesian 
-       MCDS.continuum_variables(i+1).raw_data = []; % only for non-Cartesian 
-   else
-       MCDS.continuum_variables(i+1).data = []; % only for Cartesian 
-       MCDS.continuum_variables(i+1).raw_data = zeros( 1 , length( MCDS.mesh.voxels) ); % only for non-Cartesian 
-   end
+for i=0:variable_tags.getLength - 1
+    MCDS.continuum_variables(i+1).name = char( variable_tags.item(i).getAttribute('name' ) );
+    MCDS.continuum_variables(i+1).units = char( variable_tags.item(i).getAttribute('units' ) );
+    MCDS.continuum_variables(i+1).diffusion_coefficient = str2double( variable_tags.item(i).getElementsByTagName( 'diffusion_coefficient' ).item(0).getTextContent );
+    MCDS.continuum_variables(i+1).decay_rate = str2double( variable_tags.item(i).getElementsByTagName( 'decay_rate' ).item(0).getTextContent );
+
+    if( Cartesian )
+        MCDS.continuum_variables(i+1).data = zeros( size(MCDS.mesh.X) ); % only for Cartesian
+        MCDS.continuum_variables(i+1).raw_data = []; % only for non-Cartesian
+    else
+        MCDS.continuum_variables(i+1).data = []; % only for Cartesian
+        MCDS.continuum_variables(i+1).raw_data = zeros( 1 , length( MCDS.mesh.voxels) ); % only for non-Cartesian
+    end
 end
 
-% now get the actual data 
-node = node.getParentNode; % scale 
-node = node.getElementsByTagName( 'data' ).item(0); 
-datatype = node.getAttribute( 'type' ); 
+% now get the actual data
+node = node.getParentNode; % scale
+node = node.getElementsByTagName( 'data' ).item(0);
+datatype = node.getAttribute( 'type' );
 
 if( strcmp( datatype, 'xml' ) )
-   % data stored in xml data vectors  
-    mylist = node.getElementsByTagName( 'data_vector' ); 
-    numvars = length( MCDS.continuum_variables ); 
-    temp = zeros( 1 , numvars ); 
-    xyz = zeros(1,3); 
-    
+    % data stored in xml data vectors
+    data_vector_tags = node.getElementsByTagName( 'data_vector' );
+    numvars = length( MCDS.continuum_variables );
+
     if( Cartesian )
-        for i=0:mylist.getLength - 1
-            n = str2num( mylist.item(i).getAttribute( 'voxel_ID' ) )+1; % which voxel 
-            xyz = MCDS.mesh.voxels(n).center ; % get its center coordinate 
-            temp = str2num( mylist.item(i).getTextContent ) ; % get the data vector 
+        for i=0:data_vector_tags.getLength - 1
+            n = str2double( data_vector_tags.item(i).getAttribute( 'voxel_ID' ) )+1; % which voxel
+            xyz = MCDS.mesh.voxels(n).center ; % get its center coordinate
+            temp = str2double( data_vector_tags.item(i).getTextContent ) ; % get the data vector
 
             % figure out the X,Y,Z indices
-            ii = find( abs( MCDS.mesh.X_coordinates - xyz(1) ) < 1e-10 , 1); 
-            jj = find( abs( MCDS.mesh.Y_coordinates - xyz(2) ) < 1e-10 , 1); 
-            kk = find( abs( MCDS.mesh.Z_coordinates - xyz(3) ) < 1e-10 , 1); 
+            ii = find( abs( MCDS.mesh.X_coordinates - xyz(1) ) < 1e-10 , 1);
+            jj = find( abs( MCDS.mesh.Y_coordinates - xyz(2) ) < 1e-10 , 1);
+            kk = find( abs( MCDS.mesh.Z_coordinates - xyz(3) ) < 1e-10 , 1);
 
             for j=1:numvars
-                MCDS.continuum_variables(j).data(jj,ii,kk) = temp(j); 
+                MCDS.continuum_variables(j).data(jj,ii,kk) = temp(j);
                 % Matlab is STOOOPID. data d_ijk at (x(i), y(j) , z(k) ) is
-                % stored in data(j,i,k) instead of data(i,j,k). 
+                % stored in data(j,i,k) instead of data(i,j,k).
             end
         end
     else
         % non-Cartesian -- just keep the pointcloud of data
-        for i=0:mylist.getLength - 1
-            n = str2num( mylist.item(i).getAttribute( 'voxel_ID' ) )+1; % which voxel 
-            temp = str2num( mylist.item(i).getTextContent ) ; % get the data vector 
+        for i=0:data_vector_tags.getLength - 1
+            n = str2double( data_vector_tags.item(i).getAttribute( 'voxel_ID' ) )+1; % which voxel
+            temp = str2double( data_vector_tags.item(i).getTextContent ) ; % get the data vector
 
             for j=1:numvars
-                MCDS.continuum_variables(j).raw_data(n) = temp(j); 
+                MCDS.continuum_variables(j).raw_data(n) = temp(j);
             end
         end
     end
-    
-end    
-    
-% data stored in a matlab file 
+
+end
+
+% data stored in a matlab file
 if( strcmp( datatype, 'matlab' ) )
-   % data stored in a matlab file data vectors  
+    % data stored in a matlab file data vectors
 
-   
-   % voxels are stored in a mat file 
-   filename = node.getElementsByTagName( 'filename' ).item(0).getTextContent;
-   % MAT = struct2array( load( char(filename) ) ); 
-   filename = sprintf( '%s/%s', directory , char(filename));   
-   MAT = load(filename); % load(char(filename)); 
-   MAT = MAT.multiscale_microenvironment; 
-   [m,n] = size(MAT);
-   
-   numvars = length( MCDS.continuum_variables ); 
-   numvoxels = length( MCDS.mesh.voxels ); 
-   xyz = zeros(1,3);  
-       
-   if( Cartesian )
-       for i=1:numvoxels
-           xyz = MCDS.mesh.voxels(i).center; % get its center coordinate 
 
-           % figure out the X,Y,Z indices
-           ii = find( abs( MCDS.mesh.X_coordinates - xyz(1) ) < 1e-10 , 1); 
-           jj = find( abs( MCDS.mesh.Y_coordinates - xyz(2) ) < 1e-10 , 1); 
-           kk = find( abs( MCDS.mesh.Z_coordinates - xyz(3) ) < 1e-10 , 1); 
+    % voxels are stored in a mat file
+    filename = node.getElementsByTagName( 'filename' ).item(0).getTextContent;
+    % MAT = struct2array( load( char(filename) ) );
+    filename = sprintf( '%s/%s', directory , char(filename));
+    MAT = load(filename); % load(char(filename));
+    MAT = MAT.multiscale_microenvironment;
 
-           for j=1:numvars
-                MCDS.continuum_variables(j).data(jj,ii,kk) = MAT(4+j,i); 
-                % Matlab is STOOOPID. data d_ijk at (x(i), y(j) , z(k) ) is
-                % stored in data(j,i,k) instead of data(i,j,k). 
-           end
-       end
-   end
-   
-   if( Cartesian == false )
-       % non-Cartesian -- just keep the pointcloud of data
-       for i=1:numvoxels
+    numvars = length( MCDS.continuum_variables );
+    numvoxels = length( MCDS.mesh.voxels );
+
+    if( Cartesian )
+        for i=1:numvoxels
+            xyz = MCDS.mesh.voxels(i).center; % get its center coordinate
+
+            % figure out the X,Y,Z indices
+            ii = find( abs( MCDS.mesh.X_coordinates - xyz(1) ) < 1e-10 , 1);
+            jj = find( abs( MCDS.mesh.Y_coordinates - xyz(2) ) < 1e-10 , 1);
+            kk = find( abs( MCDS.mesh.Z_coordinates - xyz(3) ) < 1e-10 , 1);
+
             for j=1:numvars
-                MCDS.continuum_variables(j).raw_data(i) = MAT(4+j,i); 
+                MCDS.continuum_variables(j).data(jj,ii,kk) = MAT(4+j,i);
+                % Matlab is STOOOPID. data d_ijk at (x(i), y(j) , z(k) ) is
+                % stored in data(j,i,k) instead of data(i,j,k).
             end
-       end
-   end
-    
-end    
+        end
+    end
+
+    if( ~Cartesian )
+        % non-Cartesian -- just keep the pointcloud of data
+        for i=1:numvoxels
+            for j=1:numvars
+                MCDS.continuum_variables(j).raw_data(i) = MAT(4+j,i);
+            end
+        end
+    end
+
+end
+
+end
+
+function MCDS = locfn__read_cellular_information( MCDS, node, directory )
 
 % read cell populations
 
-node = node.getParentNode.getParentNode.getParentNode; 
-node = node.getElementsByTagName( 'cell_populations' ).item(0) ; 
+% node = node.getParentNode.getParentNode.getParentNode;
+node = node.getElementsByTagName( 'cellular_information' ).item(0) ;
+node = node.getElementsByTagName( 'cell_populations' ).item(0);
 
-% creating "blank" structures and preallocating memory cuts 
-% processing time. 
+% creating "blank" structures and preallocating memory cuts
+% processing time.
 
-blank_phenotype.geometrical_properties.volumes.total_volume = 0; 
-blank_phenotype.geometrical_properties.lengths.radius = 0; 
+blank_phenotype.geometrical_properties.volumes.total_volume = 0;
+blank_phenotype.geometrical_properties.lengths.radius = 0;
 
 blank_transport_variable.name = '';
 blank_transport_variable.export_rate = 0;
 blank_transport_variable.import_rate = 0;
 blank_transport_variable.saturation_density = 0;
 
-num_substrates = length( MCDS.continuum_variables );                
+num_substrates = length( MCDS.continuum_variables );
 for k=1:num_substrates
-    blank_phenotype.transport_processes.variable(k) = blank_transport_variable; 
-    blank_phenotype.transport_processes.variable(k).name = MCDS.continuum_variables(k).name; 
+    blank_phenotype.transport_processes.variable(k) = blank_transport_variable;
+    blank_phenotype.transport_processes.variable(k).name = MCDS.continuum_variables(k).name;
 end
 
 blank_state.position = [0 0 0];
 
-blank_cell.phenotype = blank_phenotype; 
+blank_cell.phenotype = blank_phenotype;
 blank_cell.state = blank_state;
 
-mylist = []; 
-if( isempty( node ) == false )
-    mylist = node.getElementsByTagName( 'cell_population' ); 
+cell_population_tags = [];
+if( ~isempty( node ) )
+    cell_population_tags = node.getElementsByTagName( 'cell_population' );
 end
- 
-MCDS.discrete_cells = blank_cell;  
 
+MCDS.discrete_cells = blank_cell;
 
+if( ~isempty( cell_population_tags ) )
 
+    for cell_pop_ind=0:cell_population_tags.getLength-1
+        node1 = cell_population_tags.item(cell_pop_ind); % cell_population
+        poptype = char( node1.getAttribute('type') );
 
-if( isempty( mylist ) == false )
-    
-    for i=0:mylist.getLength-1
-        node1 = mylist.item(i); % cell_population 
-        poptype = char( node1.getAttribute('type') ); 
-        
-        individual_type = false; 
-        if( strcmp( poptype , 'individual' ) )
-            individual_type = true; 
-        end
-        
-        custom_node = node1.getElementsByTagName( 'custom' ).item(0); 
-        custom = false; 
-        if( isempty( custom_node ) == false )
-            custom = true;
-        end
-            
-        if( individual_type == true && custom == false )
-            mylist1 = mylist.item(i).getElementsByTagName( 'cell' ); 
+        is_individual_type = strcmp( poptype , 'individual' );
 
-            numcells = mylist1.getLength; 
+        custom_node = node1.getElementsByTagName( 'custom' ).item(0);
+        has_custom = ~isempty( custom_node );
 
-			MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume = zeros( 1, numcells ); 
-			MCDS.discrete_cells.phenotype.geometrical_properties.lengths.radius = zeros( 1, numcells ); 
-			for j=1:num_substrates
-				MCDS.discrete_cells.phenotype.transport_processes.variable(j).export_rate = zeros(1,numcells);
-				MCDS.discrete_cells.phenotype.transport_processes.variable(j).import_rate = zeros(1,numcells);
-				MCDS.discrete_cells.phenotype.transport_processes.variable(j).saturation_density = zeros(1,numcells);
-			end					
-			
-			MCDS.discrete_cells.state.position = zeros( numcells , 3 ); 
-			
-			my_constant = 3.0 / (4.0*pi);
-			
-            for j=0:mylist1.getLength-1
-                node2 = mylist1.item(j).getElementsByTagName('phenotype').item(0); 
-                node3 = node2.getElementsByTagName('geometrical_properties').item(0); 
-                node3 = node3.getElementsByTagName('volumes').item(0).getElementsByTagName('total_volume').item(0); 
-                vol = str2num( node3.getTextContent ); 
-				
-				MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume(j+1) = vol; 
+        if( is_individual_type && ~has_custom )
+            cell_tags = cell_population_tags.item(cell_pop_ind).getElementsByTagName( 'cell' );
+
+            numcells = cell_tags.getLength;
+
+            MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume = zeros( 1, numcells );
+            MCDS.discrete_cells.phenotype.geometrical_properties.lengths.radius = zeros( 1, numcells );
+            for j=1:num_substrates
+                MCDS.discrete_cells.phenotype.transport_processes.variable(j).export_rate = zeros(1,numcells);
+                MCDS.discrete_cells.phenotype.transport_processes.variable(j).import_rate = zeros(1,numcells);
+                MCDS.discrete_cells.phenotype.transport_processes.variable(j).saturation_density = zeros(1,numcells);
+            end
+
+            MCDS.discrete_cells.state.position = zeros( numcells , 3 );
+
+            for j=0:cell_tags.getLength-1
+                node2 = cell_tags.item(j).getElementsByTagName('phenotype').item(0);
+                node3 = node2.getElementsByTagName('geometrical_properties').item(0);
+                node3 = node3.getElementsByTagName('volumes').item(0).getElementsByTagName('total_volume').item(0);
+                vol = str2double( node3.getTextContent );
+
+                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume(j+1) = vol;
                 MCDS.discrete_cells.phenotype.geometrical_properties.lengths.radius(j+1) = ( 3/(4*vol*pi) )^(1/3);
 
-                % transport processes 
+                % transport processes
                 node3 = node2.getElementsByTagName('transport_processes' ).item(0);
                 mylist2 = node3.getElementsByTagName( 'variable' );
                 for k = 0:mylist2.getLength -1
                     % MCDS.discrete_cells.cells(j+1).phenotype.transport_processes.variable(k+1).name = char( mylist2.item(k).getAttribute( 'name' ) );
-                    MCDS.discrete_cells.phenotype.transport_processes.variable(k+1).export_rate(j+1) = str2num( mylist2.item(k).getElementsByTagName('export_rate').item(0).getTextContent ); 
-                    MCDS.discrete_cells.phenotype.transport_processes.variable(k+1).import_rate(j+1) = str2num( mylist2.item(k).getElementsByTagName('import_rate').item(0).getTextContent ); 
-                    MCDS.discrete_cells.phenotype.transport_processes.variable(k+1).saturation_density(j+1) = str2num( mylist2.item(k).getElementsByTagName('saturation_density').item(0).getTextContent ); 
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(k+1).export_rate(j+1) = str2double( mylist2.item(k).getElementsByTagName('export_rate').item(0).getTextContent );
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(k+1).import_rate(j+1) = str2double( mylist2.item(k).getElementsByTagName('import_rate').item(0).getTextContent );
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(k+1).saturation_density(j+1) = str2double( mylist2.item(k).getElementsByTagName('saturation_density').item(0).getTextContent );
                 end
 
-                node2 = node2.getParentNode.getParentNode; 
+                node2 = node2.getParentNode.getParentNode;
                 node3 = node2.getElementsByTagName( 'state' ).item(0);
 
-                MCDS.discrete_cells.state.position(j+1,:) = str2num( node3.getElementsByTagName( 'position' ).item(0).getTextContent ); 
+                MCDS.discrete_cells.state.position(j+1,:) = str2double( node3.getElementsByTagName( 'position' ).item(0).getTextContent );
             end
         end
 
-        % deal with the case where we stored a simplified data structure 
+        % deal with the case where we stored a simplified data structure
         % as a matlab file
-        if( individual_type == true && custom == true )
-            
-            % first, get the BioFVM stuff 
-            mylist_temp = custom_node.getElementsByTagName( 'simplified_data' ); 
-            filename = []; 
-            if( isempty( mylist_temp ) == false )
-                filename = char( mylist_temp.item(0).getElementsByTagName( 'filename').item(0).getTextContent ); 
-            end
-            
-            if( isempty( filename ) == false )
-                % load the matlab file, and determine the number of cells 
-                % MAT = struct2array( load( filename ) ); 
-                filename = sprintf( '%s/%s', directory , char(filename));   
-                MAT = load(filename); % load(char(filename)); 
-                MAT = MAT.basic_agents; % use this instead of struct2array for better octave compatibility 
-                
-                [m,numcells] = size(MAT); 
-               
-                % ID, x,y,z, volume,  src,sink,saturation (multiple) 
-				
-				MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume = zeros( 1, numcells ); 
-				MCDS.discrete_cells.phenotype.geometrical_properties.lengths.radius = zeros( 1, numcells ); 
-				for j=1:num_substrates
-					MCDS.discrete_cells.phenotype.transport_processes.variable(j).export_rate = zeros(1,numcells);
-					MCDS.discrete_cells.phenotype.transport_processes.variable(j).import_rate = zeros(1,numcells);
-					MCDS.discrete_cells.phenotype.transport_processes.variable(j).saturation_density = zeros(1,numcells);
-				end					
-				
-				MCDS.discrete_cells.state.position = zeros( numcells , 3 ); 
-				
-                % fill out the cells 
-				MCDS.discrete_cells.state.position(:,1:3) = MAT(2:4,:)'; 
-				MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume = MAT(5,:)'; 
-                my_constant = 3.0 / 4.0 / pi; 
-                MCDS.discrete_cells.phenotype.geometrical_properties.lengths.radius = ( my_constant * MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume ).^(1/3); 
-				
-                num_substrates = length( MCDS.continuum_variables );        
+        if( is_individual_type && has_custom )
 
-				ind = 5; 
-				for j=1:num_substrates
-					ind = 6+3*(j-1); 
-					MCDS.discrete_cells.phenotype.transport_processes.variable(j).export_rate = MAT(ind,:)'; 
-					MCDS.discrete_cells.phenotype.transport_processes.variable(j).import_rate = MAT(ind+1,:)';
-					MCDS.discrete_cells.phenotype.transport_processes.variable(j).saturation_density = MAT(ind+2,:)';
-				end					
-
-                clear MAT; 
-                
+            % first, get the BioFVM stuff
+            simplified_data_tags = custom_node.getElementsByTagName( 'simplified_data' );
+            filename = [];
+            if( ~isempty( simplified_data_tags ) )
+                filename = char( simplified_data_tags.item(0).getElementsByTagName( 'filename').item(0).getTextContent );
             end
-            % start
 
-            % now get the PhysiCell matlab extended data 
-            filename = []; 
-            if( isempty( mylist_temp ) == false )
-                filename = char( mylist_temp.item(1).getElementsByTagName( 'filename').item(0).getTextContent ); 
-            end
-            
-            if( isempty( filename ) == false )
-                disp( filename ) 
-                % load the matlab file, and determine the number of cells 
-                % MAT = struct2array( load( filename ) ); 
-                filename = sprintf( '%s/%s', directory , char(filename));   
-                MAT = load(filename); % load(char(filename)); 
-                MAT = MAT.cells; % use this instead of struct2array for better octave compatibility 
-                
-                [m,numcells] = size(MAT); 
-                
-                % <label index="0" size="1">ID</label> % 1 
+            if( ~isempty( filename ) )
+                % load the matlab file, and determine the number of cells
+                % MAT = struct2array( load( filename ) );
+                filename = sprintf( '%s/%s', directory , char(filename));
+                MAT = load(filename); % load(char(filename));
+                MAT = MAT.cells; % use this instead of struct2array for better octave compatibility
+
+                numcells = size(MAT, 2);
+
+                % ID, x,y,z, volume,  src,sink,saturation (multiple)
+
+                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume = zeros( 1, numcells );
+                MCDS.discrete_cells.phenotype.geometrical_properties.lengths.radius = zeros( 1, numcells );
+                for j=1:num_substrates
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(j).export_rate = zeros(1,numcells);
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(j).import_rate = zeros(1,numcells);
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(j).saturation_density = zeros(1,numcells);
+                end
+
+                MCDS.discrete_cells.state.position = zeros( numcells , 3 );
+
+                % fill out the cells
+                MCDS.discrete_cells.state.position(:,1:3) = MAT(2:4,:)';
+                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume = MAT(5,:)';
+                my_constant = 3.0 / 4.0 / pi;
+                MCDS.discrete_cells.phenotype.geometrical_properties.lengths.radius = ( my_constant * MCDS.discrete_cells.phenotype.geometrical_properties.volumes.total_volume ).^(1/3);
+
+                num_substrates = length( MCDS.continuum_variables );
+
+                for j=1:num_substrates
+                    ind = 6+3*(j-1);
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(j).export_rate = MAT(ind,:)';
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(j).import_rate = MAT(ind+1,:)';
+                    MCDS.discrete_cells.phenotype.transport_processes.variable(j).saturation_density = MAT(ind+2,:)';
+                end
+
+                % <label index="0" size="1">ID</label> % 1
                 % <label index="1" size="3">position</label> % 2:4
                 % <label index="4" size="1">total_volume</label> % 5
 
@@ -473,117 +466,86 @@ if( isempty( mylist ) == false )
                 MCDS.discrete_cells.metadata.type = int8( MAT(6,:) );
 
                 % <label index="6" size="1">cycle_model</label>
-                MCDS.discrete_cells.phenotype.cycle.cycle_model = int8( MAT(7,:) ); 
+                MCDS.discrete_cells.phenotype.cycle.cycle_model = int8( MAT(7,:) );
                 % <label index="7" size="1">current_phase</label>
-                MCDS.discrete_cells.phenotype.cycle.current_phase = int8( MAT(8,:) ); 
+                MCDS.discrete_cells.phenotype.cycle.current_phase = int8( MAT(8,:) );
                 % <label index="8" size="1">elapsed_time_in_phase</label>
-                MCDS.discrete_cells.phenotype.cycle.elapsed_time_in_phase = ( MAT(9,:) ); 
-                
+                MCDS.discrete_cells.phenotype.cycle.elapsed_time_in_phase = ( MAT(9,:) );
+
                 % <label index="9" size="1">nuclear_volume</label>
-                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.nuclear = ( MAT(10,:) ); 
+                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.nuclear = ( MAT(10,:) );
                 % <label index="10" size="1">cytoplasmic_volume</label>
-                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.cytoplasmic = ( MAT(11,:) ); 
+                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.cytoplasmic = ( MAT(11,:) );
                 % <label index="11" size="1">fluid_fraction</label>
-                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.fluid_fraction = ( MAT(12,:) ); 
+                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.fluid_fraction = ( MAT(12,:) );
                 % <label index="12" size="1">calcified_fraction</label>
-                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.calcified_fraction = ( MAT(13,:) ); 
+                MCDS.discrete_cells.phenotype.geometrical_properties.volumes.calcified_fraction = ( MAT(13,:) );
 
                 % <label index="13" size="3">orientation</label>
-                MCDS.discrete_cells.state.orientation = MAT(14:16,:)'; 
+                MCDS.discrete_cells.state.orientation = MAT(14:16,:)';
                 % <label index="16" size="1">polarity</label>
-                MCDS.discrete_cells.state.polarity = MAT(17,:); 
+                MCDS.discrete_cells.state.polarity = MAT(17,:);
 
                 % <label index="17" size="1">migration_speed</label>
-                MCDS.discrete_cells.phenotype.motility.migration_speed = MAT(18,:); 
+                MCDS.discrete_cells.phenotype.motility.migration_speed = MAT(18,:);
                 % <label index="18" size="3">motility_vector</label>
-                MCDS.discrete_cells.phenotype.motility.motility_vector = MAT(19:21,:)'; 
+                MCDS.discrete_cells.phenotype.motility.motility_vector = MAT(19:21,:)';
                 % <label index="21" size="1">migration_bias</label>
-                MCDS.discrete_cells.phenotype.motility.migration_bias = MAT(22,:); 
+                MCDS.discrete_cells.phenotype.motility.migration_bias = MAT(22,:);
                 % <label index="22" size="3">motility_bias_direction</label>
-                MCDS.discrete_cells.phenotype.motility.motility_bias_direction = MAT(23:25,:)'; 
+                MCDS.discrete_cells.phenotype.motility.motility_bias_direction = MAT(23:25,:)';
                 % <label index="25" size="1">persistence_time</label>
-                MCDS.discrete_cells.phenotype.motility.persistence_time = MAT(26,:); 
+                MCDS.discrete_cells.phenotype.motility.persistence_time = MAT(26,:);
                 % <label index="26" size="1">motility_reserved</label>
 
                 % now get custom variables
-                
-                simplified_data_node1 = custom_node.getElementsByTagName( 'simplified_data' ).item(1); 
-                labels_node = simplified_data_node1.getElementsByTagName( 'labels' ).item(0); 
-                
-                labels = labels_node.getElementsByTagName( 'label' ) ; 
-                
-                custom_variables_done = false; 
-                max_label_index = labels.getLength-1; 
-                
-                custom = []; 
-                
-                i = 19; 
-                new_variable_index = 1; 
-                while( i <= max_label_index && custom_variables_done == false )
-                    mysize = int8( str2num( labels.item(i).getAttribute('size') ) ); 
-                    myindex = int8( str2num( labels.item(i).getAttribute('index')) )+1; 
-                    
-                    newname = char(labels.item(i).getTextContent); 
-                    newname = strrep( newname, ' ', '_' ); % replace( newname, ' ', '_' ); 
-                    
-                    newdata = MAT(myindex:myindex+mysize-1,:); 
+
+                % simplified_data_node1 = custom_node.getElementsByTagName( 'simplified_data' ).item(1);
+                labels_node = simplified_data_tags.item(0).getElementsByTagName( 'labels' ).item(0);
+
+                labels = labels_node.getElementsByTagName( 'label' ) ;
+
+                max_label_index = labels.getLength-1;
+
+                custom = [];
+
+                for label_ind = 19:max_label_index
+                    mysize = int8( str2double( labels.item(label_ind).getAttribute('size') ) );
+                    myindex = int8( str2double( labels.item(label_ind).getAttribute('index')) )+1;
+
+                    newname = char(labels.item(label_ind).getTextContent);
+                    newname = strrep( newname, ' ', '_' ); % replace( newname, ' ', '_' );
+
+                    newdata = MAT(myindex:myindex+mysize-1,:);
                     if( mysize > 1 )
-                        newdata = newdata'; 
+                        newdata = newdata';
                     end
-                    
-                    custom = setfield( custom, newname , newdata ); 
-                    
-                    i = i+1; 
+                    custom.(newname) = newdata;
                 end
-                MCDS.discrete_cells.custom = custom;  
-                clear MAT; 
-                
+                MCDS.discrete_cells.custom = custom;
             end
-            
-            
-            % end 
-            
+
+
+            % end
+
         end
 
     end
 
 else
-    MCDS.discrete_cells = []; 
-end 
-
-clear tree 
-
-
-% figure out which cells are dead or live 
-
-MCDS.discrete_cells.dead_cells = find( MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.apoptosis_death_model | ...
-    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.necrosis_death_model ); 
-MCDS.discrete_cells.live_cells = find( MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.advanced_Ki67_cycle_model | ...
-    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.basic_Ki67_cycle_model | ... 
-    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.flow_cytometry_cycle_model | ... 
-    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.flow_cytometry_separated_cycle_model | ... 
-    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.live_apoptotic_cycle_model | ... 
-    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.total_cells_cycle_model | ... 
-    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS_constants.live_cells_cycle_model );
-
-toc 
-
-%
-
-disp( sprintf('\nSummary for file %s:' , inputfile ) ); 
-disp( sprintf('Voxels: %u', length(MCDS.mesh.voxels) ) )
-disp( sprintf('Substrates: %u' , length( MCDS.continuum_variables ) ) );
-str = sprintf( '  %s (%s)' , MCDS.continuum_variables(1).name , MCDS.continuum_variables(1).units ); 
-for i=2:length( MCDS.continuum_variables )
-    str = sprintf( '%s, %s (%s)' , str, MCDS.continuum_variables(i).name , MCDS.continuum_variables(i).units ); 
-end
-disp(str); 
-if( isempty( MCDS.discrete_cells ) == false )
-    disp( sprintf('Cells: %u' , size( MCDS.discrete_cells.state.position , 1) ) );
-else
-    disp( 'Cells: 0' ); 
+    MCDS.discrete_cells = [];
 end
 
+% figure out which cells are dead or live
 
+MCDS.discrete_cells.dead_cells = find( MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.apoptosis_death_model | ...
+    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.necrosis_death_model );
+MCDS.discrete_cells.live_cells = find( MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.advanced_Ki67_cycle_model | ...
+    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.basic_Ki67_cycle_model | ...
+    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.flow_cytometry_cycle_model | ...
+    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.flow_cytometry_separated_cycle_model | ...
+    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.live_apoptotic_cycle_model | ...
+    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.total_cells_cycle_model | ...
+    MCDS.discrete_cells.phenotype.cycle.cycle_model == MCDS.constants.live_cells_cycle_model );
 
-return; 
+end


### PR DESCRIPTION
Responsive to issue raised in slack re bugs in using the `matlab/read_MultiCellDS_xml.m` script. Perhaps arose due to changes in multicellds output without synching the matlab implementation. see below for details

Bugs handled:
* only one `simplified_data` tag. don't look for another
* `MAT.basic_agents` --> `MAT.cells`

Other changes:
* refactored `matlab/read_MultiCellDS_xml.m` to use local functions
* some renaming of nodes to make more readable
* use `str2double` for efficiency (but really to make matlab not cry)
* eliminate unused variables for efficiency (but also for the not crying thing)
* `== false` --> `~`
* more efficient `setfield` implemented (no matlab, no cry)
* includes `MCDS_constants` in `MCDS.constants`