### PR TITLE
apply rules BEFORE checking for transformation

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1170,6 +1170,9 @@ void Cell::convert_to_cell_definition( Cell_Definition& cd )
                 * phenotype.mechanics.relative_maximum_adhesion_distance;
         }
 	}
+
+	if( PhysiCell_settings.rules_enabled )
+	{ apply_ruleset( this ); } // don't wait for the start of the next phenotype update to apply the rules to this cell
 	return; 
 }
 

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -313,14 +313,16 @@ void Cell::update_motility_vector( double dt_ )
 
 void Cell::advance_bundled_phenotype_functions( double dt_ )
 {
-	// New March 2022
-	// perform transformations 
-	standard_cell_transformations( this,this->phenotype,dt_ ); 
 
 	// New March 2023 in Version 1.12.0 
 	// call the rules-based code to update the phenotype 
 	if( PhysiCell_settings.rules_enabled )
 	{ apply_ruleset( this ); }
+
+	// New March 2022
+	// perform transformations 
+	standard_cell_transformations( this,this->phenotype,dt_ ); 
+	
 	if( get_single_signal(this,"necrotic") > 0.5 )
 	{
 		double rupture = this->phenotype.volume.rupture_volume; 


### PR DESCRIPTION
Everything else (in phenotype updates) is after applying the rules. with it ordered previously (transform then apply rules), it is possible for cells at the beginning of a sim to transform before the rule inhibiting it is applied.