### PR TITLE
cleanup random_seed

### DIFF
--- a/sample_projects/asymmetric_division/config/PhysiCell_settings.xml
+++ b/sample_projects/asymmetric_division/config/PhysiCell_settings.xml
@@ -538,7 +538,6 @@
     </cell_rules>
 
     <user_parameters>
-        <random_seed type="int" units="dimensionless" description="">0</random_seed>
         <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">0</number_of_cells>
     </user_parameters>
 </PhysiCell_settings>

--- a/sample_projects/asymmetric_division/custom_modules/custom.cpp
+++ b/sample_projects/asymmetric_division/custom_modules/custom.cpp
@@ -69,9 +69,6 @@
 
 void create_cell_types( void )
 {
-	// set the random seed 
-	SeedRandom( parameters.ints("random_seed") );  
-	
 	/* 
 	   Put any modifications to default cell definition here if you 
 	   want to have "inherited" by other cell types. 


### PR DESCRIPTION
Cleanup the use of random_seed in the `asymmetric_division` sample project. This will prevent displaying the "!" warning in the Studio `Config Basics` tab.
* remove it from `user_parameters`
* remove loading it as a user param in custom.cpp