### PR TITLE
handle abspath for output folder creation

### DIFF
--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -329,15 +329,14 @@ bool create_directories(const std::string &path)
     std::string currentPath;
 
 	// Check for Unix-like absolute path or Windows absolute path with drive letter
-#if defined(__MINGW32__) || defined(__MINGW64__)
-	if (path[0] == '\\')
-	{ pos = 1; } // Windows absolute path starting with backslash
-	else if (path.length() > 2 && isalpha(path[0]) && path[1] == ':' && path[2] == '\\')
-	{ pos = 3; } // Windows absolute path with drive letter
-#else
-	if (path[0] == '/')
-	{ pos = 1; } // Unix-like absolute path
-#endif
+	if (path[0] == '\\' || path[0] == '/')
+	{
+		pos = 1; // Unix-like or Windows absolute path starting with backslash or forward slash
+	}
+	else if (path.length() > 2 && isalpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/'))
+	{
+		pos = 3; // Windows absolute path with drive letter
+	}
 
 	while ((pos = path.find_first_of("/\\", pos)) != std::string::npos) {
         currentPath = path.substr(0, pos++);

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -325,11 +325,21 @@ void PhysiCell_Settings::read_from_pugixml( void )
 
 bool create_directories(const std::string &path)
 {
-	std::vector<std::string> directories;
-	size_t pos = 0;
+    size_t pos = 0;
     std::string currentPath;
 
-    while ((pos = path.find_first_of("/\\", pos)) != std::string::npos) {
+	// Check for Unix-like absolute path or Windows absolute path with drive letter
+#if defined(__MINGW32__) || defined(__MINGW64__)
+	if (path[0] == '\\')
+	{ pos = 1; } // Windows absolute path starting with backslash
+	else if (path.length() > 2 && isalpha(path[0]) && path[1] == ':' && path[2] == '\\')
+	{ pos = 3; } // Windows absolute path with drive letter
+#else
+	if (path[0] == '/')
+	{ pos = 1; } // Unix-like absolute path
+#endif
+
+	while ((pos = path.find_first_of("/\\", pos)) != std::string::npos) {
         currentPath = path.substr(0, pos++);
         if (!create_directory(currentPath)) {
             return false;


### PR DESCRIPTION
any path starting with the path separator (indicating an absolute path) will cause an error with the current implementation _even if the path already exists_. This is because it attempts to create a directory with the empty string. This handles checking for that case. It splits on OS to check the path separator. For windows, it checks for the abspath starting with the drive. If we can upgrade to c++17, we could take advantage of `std::filesystem` to greatly simplify this. something like 

```
// Function that we could use if we used c++17
// THIS IS NOT WHAT IS IMPLEMENTED IN THIS PR
bool create_directories(const std::string &path)
{
    std::error_code ec;
    bool success = std::filesystem::create_directories(path, ec);
    if (!success && ec) {
        // Handle error or log it, if necessary
        return false;
    }
    return true;
}
```