### PR TITLE
initialize total_attack_time to 0.0

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -248,7 +248,7 @@ Cell_State::Cell_State()
 	number_of_nuclei = 1; 
 	
 	// damage = 0.0; 
-	// total_attack_time = 0.0; 
+	total_attack_time = 0.0;
 	
 	contact_with_basement_membrane = false; 
 


### PR DESCRIPTION
Previously, it was unset and so it seems one cell (the first placed?) would have an arbitrary value.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3970a9c6-73f3-4d7f-94b0-744175dd6d09"><img width="200" alt="image" src="https://github.com/user-attachments/assets/23da7309-2cde-451a-894a-680d7640a887">
