### PR TITLE
fix buffer bug in writing coords in xml

### DIFF
--- a/BioFVM/BioFVM_MultiCellDS.cpp
+++ b/BioFVM/BioFVM_MultiCellDS.cpp
@@ -570,36 +570,9 @@ void add_BioFVM_substrates_to_open_xml_pugi( pugi::xml_document& xml_dom , std::
 		// if Cartesian, add the x, y, and z coordinates 
 		if( M.mesh.Cartesian_mesh == true )
 		{
-			char temp [10240];
-			int position = 0; 
-			for( unsigned int k=0 ; k < M.mesh.x_coordinates.size()-1 ; k++ )
-			{ position += sprintf( temp+position, "%f " , M.mesh.x_coordinates[k] ); }
-			sprintf( temp+position , "%f" , M.mesh.x_coordinates[ M.mesh.x_coordinates.size()-1] ); 
-			node = node.append_child( "x_coordinates" ); 
-			node.append_child( pugi::node_pcdata ).set_value( temp ); 
-			attrib = node.append_attribute("delimiter");
-			attrib.set_value( " " ); 
-			
-			node = node.parent();
-			position = 0; 
-			for( unsigned int k=0 ; k < M.mesh.y_coordinates.size()-1 ; k++ )
-			{ position += sprintf( temp+position, "%f " , M.mesh.y_coordinates[k] ); }
-			sprintf( temp+position , "%f" , M.mesh.y_coordinates[ M.mesh.y_coordinates.size()-1] ); 
-			node = node.append_child( "y_coordinates" ); 
-			node.append_child( pugi::node_pcdata ).set_value( temp ); 
-			attrib = node.append_attribute("delimiter");
-			attrib.set_value( " " ); 
-			
-			node = node.parent();
-			position = 0; 
-			for( unsigned int k=0 ; k < M.mesh.z_coordinates.size()-1 ; k++ )
-			{ position += sprintf( temp+position, "%f " , M.mesh.z_coordinates[k] ); }
-			sprintf( temp+position , "%f" , M.mesh.z_coordinates[ M.mesh.z_coordinates.size()-1] ); 
-			node = node.append_child( "z_coordinates" ); 
-			node.append_child( pugi::node_pcdata ).set_value( temp ); 
-			attrib = node.append_attribute("delimiter");
-			attrib.set_value( " " ); 
-			node = node.parent(); 
+			write_coordinates_node(node, M.mesh.x_coordinates, "x_coordinates");
+			write_coordinates_node(node, M.mesh.y_coordinates, "y_coordinates");
+			write_coordinates_node(node, M.mesh.z_coordinates, "z_coordinates");
 		}
 		// write out the voxels -- minimal data, even if redundant for cartesian 
 		if( save_mesh_as_matlab == false )
@@ -750,7 +723,7 @@ void add_BioFVM_substrates_to_open_xml_pugi( pugi::xml_document& xml_dom , std::
 			{ filename_start++; } 
 			strcpy( filename_without_pathing , filename_start ); 
 			
-			node.append_child( pugi::node_pcdata ).set_value( filename_without_pathing ); // filename );				
+			node.append_child( pugi::node_pcdata ).set_value( filename_without_pathing ); // filename ); 
 			
 			node = node.parent(); 
 		}
@@ -816,6 +789,21 @@ void add_BioFVM_substrates_to_open_xml_pugi( pugi::xml_document& xml_dom , std::
 	}
 	
 	return; 
+}
+
+void write_coordinates_node(pugi::xml_node &node, const std::vector<double> &coordinates, std::string name)
+{
+    std::ostringstream oss;
+    for (size_t i = 0; i < coordinates.size(); ++i)
+    {
+        if (i != 0)
+        { oss << " "; }
+        oss << coordinates[i];
+    }
+    pugi::xml_node coord_node = node.append_child(name.c_str());
+    coord_node.append_child(pugi::node_pcdata).set_value(oss.str().c_str());
+    pugi::xml_attribute attrib = coord_node.append_attribute("delimiter");
+    attrib.set_value(" ");
 }
 
 // not yet implemented 

--- a/BioFVM/BioFVM_MultiCellDS.h
+++ b/BioFVM/BioFVM_MultiCellDS.h
@@ -187,6 +187,8 @@ void add_BioFVM_basic_agent_to_open_xml_pugi(  pugi::xml_document& xml_dom, Basi
 void add_BioFVM_agents_to_open_xml_pugi( pugi::xml_document& xml_dom, std::string filename_base, Microenvironment& M  ); 
 void add_BioFVM_to_open_xml_pugi( pugi::xml_document& xml_dom , std::string filename_base, double current_simulation_time , Microenvironment& M );
 
+void write_coordinates_node(pugi::xml_node &node, const std::vector<double> &coordinates, std::string name);
+
 void save_BioFVM_to_MultiCellDS_xml_pugi( std::string filename_base , Microenvironment& M , double current_simulation_time); 
 
 /* beta in PhysiCell 1.11.0 */


### PR DESCRIPTION
sidestep issue of overflowing buffer in writing the coordinates to the xmls by using `std::ostringstream`. Note: PhysiBoSS does use this already in `BooleanNetwork.h`