### PR TITLE
fix bug in export rules

### DIFF
--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -2193,7 +2193,7 @@ void export_rules_csv_v1( std::string filename )
 				{ response = "decreases"; max_response = min_value; }
 				double half_max = pHRS->rules[k]->half_maxes[i];
 				double hill_power = pHRS->rules[k]->hill_powers[i];
-				bool use_for_dead = false; 
+				bool use_for_dead = pHRS->rules[k]->applies_to_dead_cells[i];
 
 				// output the rule 
 				fs << cell_type << "," << signal << "," << response << "," << behavior << "," // 0,1,2,3
@@ -2222,7 +2222,7 @@ void export_rules_csv_v3( std::string filename )
 		return; 
 	}
 
-	std::cout << "Exporting rules to file " << filename << " (v2 format) ... " << std::endl; 
+	std::cout << "Exporting rules to file " << filename << " (v3 format) ... " << std::endl; 
 
 	for( int n=0; n < cell_definitions_by_index.size(); n++ )
 	{
@@ -2249,7 +2249,7 @@ void export_rules_csv_v3( std::string filename )
 				{ response = "decreases"; max_response = min_value; }
 				double half_max = pHRS->rules[k]->half_maxes[i];
 				double hill_power = pHRS->rules[k]->hill_powers[i];
-				bool use_for_dead = false; 
+				bool use_for_dead = pHRS->rules[k]->applies_to_dead_cells[i];
 
 				// output the rule 
 				fs << cell_type << "," << signal << "," << response << "," << behavior << "," // 0,1,2,3
@@ -2370,7 +2370,7 @@ void setup_cell_rules( void )
 
 	// save rules (v1)
 	std::string rules_file = PhysiCell_settings.folder + "/cell_rules.csv"; 
-	export_rules_csv_v1( rules_file ); 
+	export_rules_csv_v3( rules_file ); 
 
 
 	return; 

--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -2370,6 +2370,10 @@ void setup_cell_rules( void )
 	display_behavior_dictionary( dict_of ); // done 
 	dict_of.close(); 
 
+	// save rules (v3)
+	std::string rules_file = PhysiCell_settings.folder + "/cell_rules_parsed.csv"; 
+	export_rules_csv_v3( rules_file ); 
+
 	return; 
 }
 

--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -1933,6 +1933,8 @@ void parse_rules_from_pugixml( void )
 
 			if( done == false )
 			{ std::cout << "\tWarning: Ruleset had unknown format (" << format << "). Skipping!" << std::endl; }
+			else
+			{ copy_file_to_output( input_filename ); }
 
 		}
 		else
@@ -2367,11 +2369,6 @@ void setup_cell_rules( void )
 	display_signal_dictionary( dict_of ); // done 
 	display_behavior_dictionary( dict_of ); // done 
 	dict_of.close(); 
-
-	// save rules (v1)
-	std::string rules_file = PhysiCell_settings.folder + "/cell_rules.csv"; 
-	export_rules_csv_v3( rules_file ); 
-
 
 	return; 
 }

--- a/core/PhysiCell_utilities.cpp
+++ b/core/PhysiCell_utilities.cpp
@@ -376,7 +376,7 @@ void copy_file_to_output(std::string filename)
 	char copy_command[1024];
 	sprintf(copy_command, "cp %s %s", filename.c_str(), output_filename.c_str());
 	std::cout << "Copy command: " << copy_command << std::endl;
-	system(copy_command);
+	(void)system(copy_command); // make it explicit that we are ignoring the return value
 }
 
 };


### PR DESCRIPTION
- record the value of applies_to_dead
- ~~use v3 for export (to make sharing easier)~~ do not export the rules (removed in commit [9820c77](https://github.com/MathCancer/PhysiCell/pull/318/commits/9820c77980ce8f69636d68a44d4b0bb5c68ff4d2))
- still create the .txt and .html rules files
- copy the rules file(s) (the CSVs actually read in) to the output directory