### PR TITLE
remove macos-12 from ci

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -124,29 +124,34 @@ jobs:
           {short_name: "interaction", project: "interaction-sample", name: "PhysiCell Interaction", binary: "interaction_demo", extra_run: ""},
        ]
     
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run : brew install gcc@13
+      run : |
+        if ! brew list gcc@13 &>/dev/null; then
+          brew install gcc@13
+        else
+          echo "gcc@13 is already installed."
+        fi
       
     - name: Build ${{ matrix.projects.name }} project
       run: |
-        export MACOSX_DEPLOYMENT_TARGET=12
+        export MACOSX_DEPLOYMENT_TARGET=13
         make ${{ matrix.projects.project }}
         make clean
         ${{ matrix.projects.extra_run }}
         make PHYSICELL_CPP=g++-13 static
-        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos12
+        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos13
 
     - name: Caching produced project binary 
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos12
-        key: ${{ runner.os }}-macos12-${{ github.run_id }}
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos13
+        key: ${{ runner.os }}-macos13-${{ github.run_id }}
     
     - name: Look at the generated binary
       run: |
@@ -174,11 +179,16 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run : brew install gcc@13
+      run : |
+        if ! brew list gcc@13 &>/dev/null; then
+          brew install gcc@13
+        else
+          echo "gcc@13 is already installed."
+        fi
       
     - name: Build ${{ matrix.projects.name }} project
       run: |
-        export MACOSX_DEPLOYMENT_TARGET=12
+        export MACOSX_DEPLOYMENT_TARGET=13
         make ${{ matrix.projects.project }}
         make clean
         ${{ matrix.projects.extra_run }}
@@ -212,7 +222,7 @@ jobs:
           {short_name: "interaction", project: "interaction-sample", name: "PhysiCell Interaction", binary: "interaction_demo", extra_run: ""},
         ]
         
-    runs-on: macos-12
+    runs-on: macos-13
     needs: [macos_step0a, macos_step0b]
 
     steps:
@@ -229,12 +239,12 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos12
-        key: ${{ runner.os }}-macos12-${{ github.run_id }}
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos13
+        key: ${{ runner.os }}-macos13-${{ github.run_id }}
     
     - name: Creating universal binary
       run: | 
-        lipo -create -output ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos12 ${{ matrix.projects.binary }}_macosm1
+        lipo -create -output ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos13 ${{ matrix.projects.binary }}_macosm1
 
     - name: Checking universal binary
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [
           {name: "Ubuntu", os: "ubuntu-latest", shell: "bash", compiler: "g++"},
-          {name: "MacOS 12", os: "macos-12", shell: "bash", compiler: "g++-12"},
+          {name: "MacOS 13", os: "macos-13", shell: "bash", compiler: "g++-12"},
           {name: "MacOS 14 (M1)", os: "macos-14", shell: "bash", compiler: "g++-13"},
           {name: "Windows", os: "windows-latest", shell: "msys2", compiler: "g++"},
         ]


### PR DESCRIPTION
gh actions deprecation [upcoming](https://github.com/actions/runner-images/issues/10721)
still have macos-14 ci