### PR TITLE
refactor update_all_cells

### DIFF
--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -124,12 +124,12 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 {
 	// secretions and uptakes. Syncing with BioFVM is automated. 
 
-	static double time_since_last_cycle = phenotype_dt_;
+	static double time_since_last_phenotype = phenotype_dt_;
 	static double time_since_last_mechanics = mechanics_dt_;
 	static double phenotype_threshold = phenotype_dt_ - 0.5 * diffusion_dt_;
 	static double mechanics_threshold = mechanics_dt_ - 0.5 * diffusion_dt_;
 
-	bool time_for_phenotype = time_since_last_cycle > phenotype_threshold;
+	bool time_for_phenotype = time_since_last_phenotype > phenotype_threshold;
 	bool time_for_mechanics = time_since_last_mechanics > mechanics_threshold;
 
 	#pragma omp parallel for 
@@ -174,7 +174,7 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		{
 			if( (*all_cells)[i]->is_out_of_domain == false )
 			{
-				(*all_cells)[i]->advance_bundled_phenotype_functions(time_since_last_cycle);
+				(*all_cells)[i]->advance_bundled_phenotype_functions(time_since_last_phenotype);
 			}
 		}
 		// process divides / removes 
@@ -193,10 +193,10 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		cells_ready_to_die.clear();
 		cells_ready_to_divide.clear();
 		
-		time_since_last_cycle = diffusion_dt_; // setting it for next cycle
+		time_since_last_phenotype = diffusion_dt_; // setting it for next cycle
 	}
 	else
-	{ time_since_last_cycle += diffusion_dt_; }
+	{ time_since_last_phenotype += diffusion_dt_; }
 
 	if( time_for_mechanics )
 	{

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -173,16 +173,22 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		for( int i=0; i < (*all_cells).size(); i++ )
 		{
 			if( (*all_cells)[i]->is_out_of_domain == false )
-			{ (*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle ); }
+			{
+				(*all_cells)[i]->advance_bundled_phenotype_functions(time_since_last_cycle);
+			}
 		}
 		// process divides / removes 
 		for( int i=0; i < cells_ready_to_divide.size(); i++ )
-		{ cells_ready_to_divide[i]->divide(); }
+		{
+			cells_ready_to_divide[i]->divide();
+		}
 		// remove cells here (and not only below after interactions) in case phenotype and mechanics time steps don't line up
 		for( int i=0; i < cells_ready_to_die.size(); i++ )
-		{ cells_ready_to_die[i]->die(); }
-		num_deaths_in_current_step+=  cells_ready_to_die.size();
+		{
+			cells_ready_to_die[i]->die();
+		}
 		num_divisions_in_current_step+=  cells_ready_to_divide.size();
+		num_deaths_in_current_step+=  cells_ready_to_die.size();
 		
 		cells_ready_to_die.clear();
 		cells_ready_to_divide.clear();
@@ -203,7 +209,9 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 			standard_cell_cell_interactions(pC,pC->phenotype,time_since_last_mechanics); 
 		}
 		for( int i=0; i < cells_ready_to_die.size(); i++ )
-		{ cells_ready_to_die[i]->die(); }
+		{
+			cells_ready_to_die[i]->die();
+		}
 		cells_ready_to_die.clear();
 		
 		// new February 2018 
@@ -278,8 +286,6 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 			if( pC->is_out_of_domain == false && pC->is_movable)
 			{ pC->update_position(time_since_last_mechanics); }
 		}
-		
-		// When somebody reviews this code, let's add proper braces for clarity!!! 
 		
 		// Update cell indices in the container
 		for( int i=0; i < (*all_cells).size(); i++ )

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -194,7 +194,7 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		cells_ready_to_die.clear();
 		cells_ready_to_divide.clear();
 		
-		time_since_last_cycle = 0.0;
+		time_since_last_cycle = diffusion_dt_; // setting it for next cycle
 	}
 	else
 	{ time_since_last_cycle += diffusion_dt_; }
@@ -301,7 +301,7 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 				(*all_cells)[i]->update_voxel_in_container();
 			}
 		}
-		time_since_last_mechanics = 0.0;
+		time_since_last_mechanics = diffusion_dt_; // setting it for next cycle
 	}
 	else
 	{ time_since_last_mechanics += diffusion_dt_; }

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -173,23 +173,16 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 		for( int i=0; i < (*all_cells).size(); i++ )
 		{
 			if( (*all_cells)[i]->is_out_of_domain == false )
-			{
-				(*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle ); 
-			}
+			{ (*all_cells)[i]->advance_bundled_phenotype_functions( time_since_last_cycle ); }
 		}
 		// process divides / removes 
 		for( int i=0; i < cells_ready_to_divide.size(); i++ )
-		{
-			cells_ready_to_divide[i]->divide();
-		}
+		{ cells_ready_to_divide[i]->divide(); }
 		// remove cells here (and not only below after interactions) in case phenotype and mechanics time steps don't line up
 		for( int i=0; i < cells_ready_to_die.size(); i++ )
-		{	
-			cells_ready_to_die[i]->die();	
-		}
+		{ cells_ready_to_die[i]->die(); }
 		num_deaths_in_current_step+=  cells_ready_to_die.size();
 		num_divisions_in_current_step+=  cells_ready_to_divide.size();
-		
 		
 		cells_ready_to_die.clear();
 		cells_ready_to_divide.clear();
@@ -209,13 +202,8 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 			Cell* pC = (*all_cells)[i]; 
 			standard_cell_cell_interactions(pC,pC->phenotype,time_since_last_mechanics); 
 		}
-
 		for( int i=0; i < cells_ready_to_die.size(); i++ )
-		{	
-			cells_ready_to_die[i]->die();	
-		}
-		num_deaths_in_current_step+=  cells_ready_to_die.size();
-		
+		{ cells_ready_to_die[i]->die(); }
 		cells_ready_to_die.clear();
 		
 		// new February 2018 

--- a/core/PhysiCell_cell_container.h
+++ b/core/PhysiCell_cell_container.h
@@ -84,7 +84,6 @@ class Cell_Container : public BioFVM::Agent_Container
 	std::vector<Cell*> cells_ready_to_divide; // the index of agents ready to divide
 	std::vector<Cell*> cells_ready_to_die;
 	int boundary_condition_for_pushed_out_agents; 	// what to do with pushed out cells
-	bool initialzed = false;
 	
  public:
 	BioFVM::Cartesian_Mesh underlying_mesh;

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1468,8 +1468,6 @@ void dynamic_spring_attachments( Cell* pCell , Phenotype& phenotype, double dt )
     for( int j=0; j < pCell->state.spring_attachments.size(); j++ )
     {
         Cell* pTest = pCell->state.spring_attachments[j]; 
-		if (phenotype.cell_interactions.pAttackTarget==pTest || pTest->phenotype.cell_interactions.pAttackTarget==pCell) // do not let attackers detach randomly
-		{ continue; }
         if( UniformRandom() <= detachment_probability )
         { detach_cells_as_spring( pCell , pTest ); }
     }

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1317,36 +1317,36 @@ void standard_cell_cell_interactions( Cell* pCell, Phenotype& phenotype, double 
 
 	// move effector attack here. 
 
-		if( pCell->phenotype.cell_interactions.pAttackTarget != NULL ) 
+	if( pCell->phenotype.cell_interactions.pAttackTarget != NULL ) 
+	{
+		Cell* pTarget = pCell->phenotype.cell_interactions.pAttackTarget; 
+
+		pCell->attack_cell(pTarget,dt); 
+		attacked = true; // attacked at least one cell in this time step 
+
+		// attack_cell
+
+		// probability of ending attack 
+		// end attack if target is dead 
+		probability = dt / (1e-15 + pCell->phenotype.cell_interactions.attack_duration); 
+
+
+		if( UniformRandom() < probability || pTarget->phenotype.death.dead ) 
 		{
-			Cell* pTarget = pCell->phenotype.cell_interactions.pAttackTarget; 
+			/*
+			std::cout << "*********   *********  ********  attack done **** " << PhysiCell_globals.current_time << " " 
+			<< probability << " "
+			<< "attack time: " << pTarget->state.total_attack_time << " " 		
+			<< "damage: " << pTarget->phenotype.cell_integrity.damage <<  " " 		
+			<< "dead? " << (int) pTarget->phenotype.death.dead << " " 
+			<< "damage delivered: " << pCell->phenotype.cell_interactions.total_damage_delivered << std::endl; 
+			*/
 
-			pCell->attack_cell(pTarget,dt); 
-			attacked = true; // attacked at least one cell in this time step 
+			detach_cells_as_spring(pCell,pTarget); 
 
-			// attack_cell
-
-			// probability of ending attack 
-			// end attack if target is dead 
-			probability = dt / (1e-15 + pCell->phenotype.cell_interactions.attack_duration); 
-
-
-			if( UniformRandom() < probability || pTarget->phenotype.death.dead ) 
-			{
-				/*
-				std::cout << "*********   *********  ********  attack done **** " << PhysiCell_globals.current_time << " " 
-				<< probability << " "
-				<< "attack time: " << pTarget->state.total_attack_time << " " 		
-				<< "damage: " << pTarget->phenotype.cell_integrity.damage <<  " " 		
-				<< "dead? " << (int) pTarget->phenotype.death.dead << " " 
-				<< "damage delivered: " << pCell->phenotype.cell_interactions.total_damage_delivered << std::endl; 
-				*/
-
-				detach_cells_as_spring(pCell,pTarget); 
-
-				pCell->phenotype.cell_interactions.pAttackTarget = NULL; 
-			} 
+			pCell->phenotype.cell_interactions.pAttackTarget = NULL; 
 		} 
+	} 
 
 
 	// move decision if to end attack here. 
@@ -1468,6 +1468,8 @@ void dynamic_spring_attachments( Cell* pCell , Phenotype& phenotype, double dt )
     for( int j=0; j < pCell->state.spring_attachments.size(); j++ )
     {
         Cell* pTest = pCell->state.spring_attachments[j]; 
+		if (phenotype.cell_interactions.pAttackTarget==pTest || pTest->phenotype.cell_interactions.pAttackTarget==pCell) // do not let attackers detach randomly
+		{ continue; }
         if( UniformRandom() <= detachment_probability )
         { detach_cells_as_spring( pCell , pTest ); }
     }


### PR DESCRIPTION
This is responsive to issue #320 

- fix bug in neighbor list
    - phagocytosis and fusion could result in removal of a cell
    - but the neighbor list was not updated
- resolve interactions after phenotype updates
    - this allows the update velocity step to update the neighbors list one time
    - does move interactions before several steps:
        - gradient computation
        - evaluate interactions (so fewer interactions to evaluate) 
        - custom rule 
        - update velocity 
        - springs
- ~~do not allow spontaneous spring detachments caused by attack~~ (now a separate pr in #340 )
- refactor how timing is done for simplicity