### PR TITLE
update neighbors to fix phagocytosis bug

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -318,6 +318,9 @@ void Cell::advance_bundled_phenotype_functions( double dt_ )
 	// perform transformations 
 	standard_cell_transformations( this,this->phenotype,dt_ ); 
 
+	// make sure neighbors are updated
+	state.neighbors = nearby_cells();
+	
 	// New March 2023 in Version 1.12.0 
 	// call the rules-based code to update the phenotype 
 	if( PhysiCell_settings.rules_enabled )


### PR DESCRIPTION
This is an alternate way to resolve #320. This is simpler than the way proposed in #338 but I think that one is a better rework.

## Notes
- make sure every cell has an updated neighbors list to start
- this is the simplest change (fewest lines) to fix the bug

## Warning
However, the interactions sample on Ubuntu has a 'std::bad_alloc' what(): std::bad_alloc` error thrown. I cannot reproduce this running on my Mac or a Linux-based HPC. I do not think this fix is triggering that error since none of the other tests are raising that error.