### PR TITLE
persist attack through attacker transformation

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1129,6 +1129,14 @@ void Cell::convert_to_cell_definition( Cell_Definition& cd )
 	Geometry cell_geometry = phenotype.geometry;
 	Molecular cell_molecular = phenotype.molecular;
 	Custom_Cell_Data cell_custom_data = custom_data;
+
+	// if this cell is attacking, be safe and stop the attack
+	if ( phenotype.cell_interactions.pAttackTarget != NULL )
+	{
+		detach_cells_as_spring(this, phenotype.cell_interactions.pAttackTarget);
+		// phenotype.cell_interactions.pAttackTarget = NULL; // not needed since phenotype is overwritten below
+	}
+
 	// use the cell defaults; 
 	type = cd.type; 
 	type_name = cd.name; 

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1158,12 +1158,11 @@ void Cell::convert_to_cell_definition( Cell_Definition& cd )
 	Molecular cell_molecular = phenotype.molecular;
 	Custom_Cell_Data cell_custom_data = custom_data;
 
-	// pAttackTarget is phenotype state, and the assignment below replaces it, so
-	// end this cell's own attack. attacked_by and the spring are in state, which
-	// transformation preserves, so attacks against this cell continue.
-	remove_self_from_attacked();
-	// should we also remove all attackers?  That would be a change in behavior, so for now we don't.
-	// remove_all_attackers();
+	// pAttackTarget is phenotype state, and the assignment below replaces it, so hold
+	// on to it and put it back afterwards. attacked_by and the spring are in state,
+	// which transformation preserves, so restoring pAttackTarget keeps the whole
+	// attack link intact -- matching attacks against this cell, which already persist.
+	Cell* cell_attack_target = phenotype.cell_interactions.pAttackTarget;
 
 	// use the cell defaults; 
 	type = cd.type; 
@@ -1184,6 +1183,7 @@ void Cell::convert_to_cell_definition( Cell_Definition& cd )
 	
 	phenotype.geometry = cell_geometry; // leave the geometry alone
 	phenotype.molecular.internalized_total_substrates = cell_molecular.internalized_total_substrates;
+	phenotype.cell_interactions.pAttackTarget = cell_attack_target; // leave any ongoing attack alone
 	
 	for( int nn = 0 ; nn < custom_data.variables.size() ; nn++ )
 	{

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1163,6 +1163,9 @@ void Cell::convert_to_cell_definition( Cell_Definition& cd )
 	// which transformation preserves, so restoring pAttackTarget keeps the whole
 	// attack link intact -- matching attacks against this cell, which already persist.
 	Cell* cell_attack_target = phenotype.cell_interactions.pAttackTarget;
+	// a lifetime tally of this cell's own doing, so carry it across the transformation
+	// rather than restarting it partway through an attack that is still running
+	double cell_total_damage_delivered = phenotype.cell_interactions.total_damage_delivered;
 
 	// use the cell defaults; 
 	type = cd.type; 
@@ -1184,6 +1187,7 @@ void Cell::convert_to_cell_definition( Cell_Definition& cd )
 	phenotype.geometry = cell_geometry; // leave the geometry alone
 	phenotype.molecular.internalized_total_substrates = cell_molecular.internalized_total_substrates;
 	phenotype.cell_interactions.pAttackTarget = cell_attack_target; // leave any ongoing attack alone
+	phenotype.cell_interactions.total_damage_delivered = cell_total_damage_delivered;
 	
 	for( int nn = 0 ; nn < custom_data.variables.size() ; nn++ )
 	{


### PR DESCRIPTION
Rebased onto current `development` and **inverted** relative to this PR's original direction: transformation now *keeps* an in-progress attack running instead of ending it.

### Background

- `pAttackTarget` lives in `phenotype.cell_interactions`, so `phenotype = cd.phenotype` in `convert_to_cell_definition` drops it.
- The other two halves of the attack link — the target's `state.attacked_by` and the shared spring — live in `state`, which transformation leaves alone.

Since #422 landed the symmetric attack link, `convert_to_cell_definition` resolved that mismatch by calling `remove_self_from_attacked()` to end the attack. This PR resolves it the other way: hold `pAttackTarget` across the assignment and put it back. All three parts of the link then stay consistent, and the spring is never touched.

This also makes transformation symmetric — attacks *against* a transforming cell already persisted, while attacks *by* it were ended.

`total_damage_delivered` is carried across too (second commit). It also lives in `phenotype.cell_interactions`, so transformation was resetting the attacker's lifetime damage tally to zero — visibly wrong now that the attack it was counting keeps running afterwards.

### Verification

Built and ran `interaction-sample` with `CD8+ T cell -> neutrophil` transformation enabled and a 30 min attack duration. At each transformation of an attacking cell, all three parts of the link survive:

```
TRANSFORM_WITH_ATTACK now=24 newtype=neutrophil target=bacteria \
  pAttackTarget_kept=1 target_lists_me=1 spring_mine=1 spring_theirs=1
```

`interactions` and `rules_sample` are the only sample configs with both nonzero attack and transformation rates, and neither is SVG-diff-checked in CI, so no snapshot changes are expected.

### Known gap

The same run shows the case worth flagging:

```
newtype=neutrophil attack_rate_vs_target=0 attack_damage_rate=1 attack_duration=0.1
```

The transformed cell keeps attacking a cell type its new definition has a **zero** attack rate against — an attack it could never have started — and with unset attack parameters the defaults (`attack_damage_rate = 1.0`, `attack_duration = 30 min`) let that run on.

Handled separately in #432, which warns about exactly this case without changing the simulation.
