### PR TITLE
enable update_parameter and reset density handling.

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -253,7 +253,7 @@ bool Microenvironment::get_substrate_dirichlet_activation( int substrate_index )
 // TODO? fix confusing swapped usage of args
 double Microenvironment::get_substrate_dirichlet_value( int substrate_index, int index )
 { 
-    return dirichlet_value_vectors[index][substrate_index]; 
+	return dirichlet_value_vectors[index][substrate_index];
 }  
 
 // new functions for finer-grained control of Dirichlet conditions -- 1.7.0
@@ -487,7 +487,7 @@ void Microenvironment::add_density( std::string name , std::string units )
 
 void Microenvironment::add_density( std::string name , std::string units, double diffusion_constant, double decay_rate )
 {
-	// fix in PhysiCell preview November 2017 
+	// check if density exist
 	if ( find_density_index( name ) != -1 )
 	{
 		std::cout << "ERROR: density named " << name << " already exists. You probably want your substrates all have unique names!" << std::endl;
@@ -1146,55 +1146,58 @@ Microenvironment_Options::Microenvironment_Options()
 
 Microenvironment_Options default_microenvironment_options; 
 
-void initialize_microenvironment( void )
+void initialize_microenvironment( bool reload )
 {
-	// create and name a microenvironment; 
-	microenvironment.name = default_microenvironment_options.name;
-	// register the diffusion solver 
-	if( default_microenvironment_options.simulate_2D == true )
+	if ( ! reload )
 	{
-		microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_2D; 
-	}
-	else
-	{
-		microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_3D; 
-	}
-	
-	// set the default substrate to oxygen (with typical units of mmHg)
-	if( default_microenvironment_options.use_oxygen_as_first_field == true )
-	{
-		microenvironment.set_density(0, "oxygen" , "mmHg" );
-		microenvironment.diffusion_coefficients[0] = 1e5; 
-		microenvironment.decay_rates[0] = 0.1; 
-	}
-	
-	// resize the microenvironment  
-	if( default_microenvironment_options.simulate_2D == true )
-	{
-		default_microenvironment_options.Z_range[0] = -default_microenvironment_options.dz/2.0; 
-		default_microenvironment_options.Z_range[1] = default_microenvironment_options.dz/2.0;
-	}
-	microenvironment.resize_space( default_microenvironment_options.X_range[0], default_microenvironment_options.X_range[1] , 
-		default_microenvironment_options.Y_range[0], default_microenvironment_options.Y_range[1], 
-		default_microenvironment_options.Z_range[0], default_microenvironment_options.Z_range[1], 
-		default_microenvironment_options.dx,default_microenvironment_options.dy,default_microenvironment_options.dz );
-		
-	// set units
-	microenvironment.spatial_units = default_microenvironment_options.spatial_units;
-	microenvironment.time_units = default_microenvironment_options.time_units;
-	microenvironment.mesh.units = default_microenvironment_options.spatial_units;
+		// create and name a microenvironment;
+		microenvironment.name = default_microenvironment_options.name;
+		// register the diffusion solver
+		if( default_microenvironment_options.simulate_2D == true )
+		{
+			microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_2D;
+		}
+		else
+		{
+			microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_3D;
+		}
 
-	// set the initial densities to the values set in the initial_condition_vector
-	
-	// if the initial condition vector has not been set, use the Dirichlet condition vector 
-	if( default_microenvironment_options.initial_condition_vector.size() != 
-		microenvironment.number_of_densities() )
-	{
-		std::cout << "BioFVM Warning: Initial conditions not set. " << std::endl 
-				  << "                Using Dirichlet condition vector to set initial substrate values!" << std::endl 
-				  << "                In the future, set default_microenvironment_options.initial_condition_vector." 
-				  << std::endl << std::endl;  
+		// set the default substrate to oxygen (with typical units of mmHg)
+		if( default_microenvironment_options.use_oxygen_as_first_field == true )
+		{
+			microenvironment.set_density(0, "oxygen" , "mmHg" );
+			microenvironment.diffusion_coefficients[0] = 1e5;
+			microenvironment.decay_rates[0] = 0.1;
+		}
+
+		// resize the microenvironment
+		if( default_microenvironment_options.simulate_2D == true )
+		{
+			default_microenvironment_options.Z_range[0] = -default_microenvironment_options.dz/2.0;
+			default_microenvironment_options.Z_range[1] = default_microenvironment_options.dz/2.0;
+		}
+		microenvironment.resize_space( default_microenvironment_options.X_range[0], default_microenvironment_options.X_range[1], 
+			default_microenvironment_options.Y_range[0], default_microenvironment_options.Y_range[1], 
+			default_microenvironment_options.Z_range[0], default_microenvironment_options.Z_range[1], 
+			default_microenvironment_options.dx,default_microenvironment_options.dy,default_microenvironment_options.dz );
+
+		// set units
+		microenvironment.spatial_units = default_microenvironment_options.spatial_units;
+		microenvironment.time_units = default_microenvironment_options.time_units;
+		microenvironment.mesh.units = default_microenvironment_options.spatial_units;
+
+		// set the initial densities to the values set in the initial_condition_vector
+
+		// if the initial condition vector has not been set, use the Dirichlet condition vector
+		if( default_microenvironment_options.initial_condition_vector.size() != 
+			microenvironment.number_of_densities() )
+		{
+			std::cout << "BioFVM Warning: Initial conditions not set. " << std::endl
+				  << "                Using Dirichlet condition vector to set initial substrate values!" << std::endl
+				  << "                In the future, set default_microenvironment_options.initial_condition_vector."
+				  << std::endl << std::endl;
 		default_microenvironment_options.initial_condition_vector = default_microenvironment_options.Dirichlet_condition_vector; 
+		}
 	}
 
 	// set the initial condition

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -362,7 +362,7 @@ class Microenvironment_Options
 extern Microenvironment_Options default_microenvironment_options; 
 extern Microenvironment microenvironment;
 
-void initialize_microenvironment( void ); 
+void initialize_microenvironment( bool reload = false );
 
 void load_initial_conditions_from_matlab( std::string filename );
 void load_initial_conditions_from_csv( std::string filename );

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -89,7 +89,7 @@ namespace PhysiCell{
  	
 extern pugi::xml_node physicell_config_root; 
 
-bool load_PhysiCell_config_file( std::string filename );
+bool load_PhysiCell_config_file( std::string filename , bool update_variables = false );
 
 class PhysiCell_Settings
 {
@@ -186,17 +186,20 @@ class Parameters
 	friend std::ostream& operator<<( std::ostream& os , const Parameters<Y>& params ); 
 
  public: 
-	Parameters(); 
+	Parameters();
  
-	std::vector< Parameter<T> > parameters; 
+	std::vector< Parameter<T> > parameters;
 	
-	void add_parameter( std::string my_name ); 
-	void add_parameter( std::string my_name , T my_value ); 
-	void add_parameter( std::string my_name , T my_value , std::string my_units ); 
-	
+	void add_parameter( std::string my_name );
+	void add_parameter( std::string my_name , T my_value );
+	void add_parameter( std::string my_name , T my_value , std::string my_units );
 	void add_parameter( Parameter<T> param );
+
+	void update_parameter( std::string my_name , T my_value );
+	void update_parameter( std::string my_name , T my_value , std::string my_units );
+	void update_parameter( Parameter<T> param );
 	
-	int find_index( std::string search_name ); 
+	int find_index( std::string search_name );
 	
 	// these access the values 
 	T& operator()( int i );
@@ -208,7 +211,8 @@ class Parameters
 	
 	int size( void ) const;
 
-	void assert_not_exists(std::string search_name);
+	void assert_parameter_not_exists(std::string search_name);
+	int assert_parameter_exists(std::string search_name);
 };
 
 class User_Parameters
@@ -222,7 +226,7 @@ class User_Parameters
 	Parameters<double> doubles; 
 	Parameters<std::string> strings; 
 	
-	void read_from_pugixml( pugi::xml_node parent_node );
+	void read_from_pugixml( pugi::xml_node parent_node , bool update_parameter = false );
 }; 
 
 extern PhysiCell_Globals PhysiCell_globals; 


### PR DESCRIPTION
pull request which replaces the staled pull requests: https://github.com/MathCancer/PhysiCell/pull/298, https://github.com/MathCancer/PhysiCell/pull/264, https://github.com/MathCancer/PhysiCell/pull/250 and https://github.com/MathCancer/PhysiCell/pull/232.

these are the final changes needed to run in the same runtime multiple consecutive episodes of a physicell run (one settings.xml). with this implementation, it is possible to add and update parameters from one to the next episode.
however, this implementation only supports resetting and not adding or updating cell types or densities from one to next episode.  but his is good enough for the project these changes are needed.

this pull request is compatible with physicell version 1.14.1 and keeps the changes to the existing code bases as small as possible.
default settings were chosen so that the current models not will break through these changes.

the code was extensively tested here: https://github.com/elmbeech/episode