### PR TITLE
github workflow ubuntu unit tests adjustment from gcc version 11 to version 12

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -32,7 +32,7 @@ jobs:
         make ${{ matrix.projects.project }}
         make clean
         ${{ matrix.projects.extra_run }}
-        make static STATIC_OPENMP=/usr/lib/gcc/x86_64-linux-gnu/11/libgomp.a
+        make static STATIC_OPENMP=/usr/lib/gcc/x86_64-linux-gnu/12/libgomp.a
       
     - name: Checking binary for ${{ matrix.projects.name }}
       run: |


### PR DESCRIPTION
github lately updated the latest ubuntu version, which by default runs gcc version 12.
this pull request has the required change that the linux os unit tests pass again.