### PR TITLE
enable reload setting xml file.

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -253,7 +253,7 @@ bool Microenvironment::get_substrate_dirichlet_activation( int substrate_index )
 // TODO? fix confusing swapped usage of args
 double Microenvironment::get_substrate_dirichlet_value( int substrate_index, int index )
 { 
-    return dirichlet_value_vectors[index][substrate_index]; 
+	return dirichlet_value_vectors[index][substrate_index];
 }  
 
 // new functions for finer-grained control of Dirichlet conditions -- 1.7.0
@@ -487,7 +487,7 @@ void Microenvironment::add_density( std::string name , std::string units )
 
 void Microenvironment::add_density( std::string name , std::string units, double diffusion_constant, double decay_rate )
 {
-	// fix in PhysiCell preview November 2017 
+	// check if density exist
 	if ( find_density_index( name ) != -1 )
 	{
 		std::cout << "ERROR: density named " << name << " already exists. You probably want your substrates all have unique names!" << std::endl;
@@ -1146,55 +1146,58 @@ Microenvironment_Options::Microenvironment_Options()
 
 Microenvironment_Options default_microenvironment_options; 
 
-void initialize_microenvironment( void )
+void initialize_microenvironment( bool reload )
 {
-	// create and name a microenvironment; 
-	microenvironment.name = default_microenvironment_options.name;
-	// register the diffusion solver 
-	if( default_microenvironment_options.simulate_2D == true )
+	if ( ! reload )
 	{
-		microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_2D; 
-	}
-	else
-	{
-		microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_3D; 
-	}
-	
-	// set the default substrate to oxygen (with typical units of mmHg)
-	if( default_microenvironment_options.use_oxygen_as_first_field == true )
-	{
-		microenvironment.set_density(0, "oxygen" , "mmHg" );
-		microenvironment.diffusion_coefficients[0] = 1e5; 
-		microenvironment.decay_rates[0] = 0.1; 
-	}
-	
-	// resize the microenvironment  
-	if( default_microenvironment_options.simulate_2D == true )
-	{
-		default_microenvironment_options.Z_range[0] = -default_microenvironment_options.dz/2.0; 
-		default_microenvironment_options.Z_range[1] = default_microenvironment_options.dz/2.0;
-	}
-	microenvironment.resize_space( default_microenvironment_options.X_range[0], default_microenvironment_options.X_range[1] , 
-		default_microenvironment_options.Y_range[0], default_microenvironment_options.Y_range[1], 
-		default_microenvironment_options.Z_range[0], default_microenvironment_options.Z_range[1], 
-		default_microenvironment_options.dx,default_microenvironment_options.dy,default_microenvironment_options.dz );
+		// create and name a microenvironment;
+		microenvironment.name = default_microenvironment_options.name;
+		// register the diffusion solver
+		if( default_microenvironment_options.simulate_2D == true )
+		{
+			microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_2D;
+		}
+		else
+		{
+			microenvironment.diffusion_decay_solver = diffusion_decay_solver__constant_coefficients_LOD_3D;
+		}
 		
-	// set units
-	microenvironment.spatial_units = default_microenvironment_options.spatial_units;
-	microenvironment.time_units = default_microenvironment_options.time_units;
-	microenvironment.mesh.units = default_microenvironment_options.spatial_units;
-
-	// set the initial densities to the values set in the initial_condition_vector
-	
-	// if the initial condition vector has not been set, use the Dirichlet condition vector 
-	if( default_microenvironment_options.initial_condition_vector.size() != 
-		microenvironment.number_of_densities() )
-	{
-		std::cout << "BioFVM Warning: Initial conditions not set. " << std::endl 
-				  << "                Using Dirichlet condition vector to set initial substrate values!" << std::endl 
-				  << "                In the future, set default_microenvironment_options.initial_condition_vector." 
-				  << std::endl << std::endl;  
-		default_microenvironment_options.initial_condition_vector = default_microenvironment_options.Dirichlet_condition_vector; 
+		// set the default substrate to oxygen (with typical units of mmHg)
+		if( default_microenvironment_options.use_oxygen_as_first_field == true )
+		{
+			microenvironment.set_density( 0, "oxygen" , "mmHg" );
+			microenvironment.diffusion_coefficients[0] = 1e5;
+			microenvironment.decay_rates[0] = 0.1;
+		}
+		
+		// resize the microenvironment
+		if( default_microenvironment_options.simulate_2D == true )
+		{
+			default_microenvironment_options.Z_range[0] = -default_microenvironment_options.dz/2.0;
+			default_microenvironment_options.Z_range[1] = default_microenvironment_options.dz/2.0;
+		}
+		microenvironment.resize_space( default_microenvironment_options.X_range[0], default_microenvironment_options.X_range[1], 
+			default_microenvironment_options.Y_range[0], default_microenvironment_options.Y_range[1], 
+			default_microenvironment_options.Z_range[0], default_microenvironment_options.Z_range[1], 
+			default_microenvironment_options.dx,default_microenvironment_options.dy,default_microenvironment_options.dz );
+		
+		// set units
+		microenvironment.spatial_units = default_microenvironment_options.spatial_units;
+		microenvironment.time_units = default_microenvironment_options.time_units;
+		microenvironment.mesh.units = default_microenvironment_options.spatial_units;
+		
+		// set the initial densities to the values set in the initial_condition_vector
+		
+		// if the initial condition vector has not been set, use the Dirichlet condition vector
+		if( default_microenvironment_options.initial_condition_vector.size() != 
+			microenvironment.number_of_densities() )
+		{
+			std::cout << "BioFVM Warning: Initial conditions not set. " << std::endl
+				<< "                Using Dirichlet condition vector to set initial substrate values!" << std::endl
+				<< "                In the future, set default_microenvironment_options.initial_condition_vector."
+				<< std::endl << std::endl;
+			default_microenvironment_options.initial_condition_vector = default_microenvironment_options.Dirichlet_condition_vector;
+		}
 	}
 
 	// set the initial condition

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -362,7 +362,7 @@ class Microenvironment_Options
 extern Microenvironment_Options default_microenvironment_options; 
 extern Microenvironment microenvironment;
 
-void initialize_microenvironment( void ); 
+void initialize_microenvironment( bool reload = false );
 
 void load_initial_conditions_from_matlab( std::string filename );
 void load_initial_conditions_from_csv( std::string filename );

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -79,7 +79,7 @@ bool physicell_config_dom_initialized = false;
 pugi::xml_document physicell_config_doc; 	
 pugi::xml_node physicell_config_root; 
 	
-bool load_PhysiCell_config_file( std::string filename )
+bool load_PhysiCell_config_file( std::string filename , bool reload )
 {
 	std::cout << "Using config file " << filename << " ... " << std::endl ; 
 	pugi::xml_parse_result result = physicell_config_doc.load_file( filename.c_str()  );
@@ -97,17 +97,22 @@ bool load_PhysiCell_config_file( std::string filename )
 	
 	// now read the microenvironment (optional) 
 	
-	if( !setup_microenvironment_from_XML( physicell_config_root ) )
+	if ( !reload )
 	{
-		std::cout << std::endl 
-				  << "Warning: microenvironment_setup not found in " << filename << std::endl 
-				  << "         Either manually setup microenvironment in setup_microenvironment() (custom.cpp)" << std::endl
-				  << "         or consult documentation to add microenvironment_setup to your configuration file." << std::endl << std::endl; 
+		if( !setup_microenvironment_from_XML( physicell_config_root ) )
+		{
+			std::cout << std::endl
+				<< "Warning: microenvironment_setup not found in " << filename << std::endl
+				<< "         Either manually setup microenvironment in setup_microenvironment() (custom.cpp)" << std::endl
+				<< "         or consult documentation to add microenvironment_setup to your configuration file." << std::endl << std::endl;
+		}
 	}
 	
 	// now read user parameters
-	
-	parameters.read_from_pugixml( physicell_config_root ); 
+	if( !reload )
+	{
+		parameters.read_from_pugixml( physicell_config_root );
+	}
 
 	create_output_directory( PhysiCell_settings.folder );
 

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -89,7 +89,7 @@ namespace PhysiCell{
  	
 extern pugi::xml_node physicell_config_root; 
 
-bool load_PhysiCell_config_file( std::string filename );
+bool load_PhysiCell_config_file( std::string filename , bool reload = false );
 
 class PhysiCell_Settings
 {


### PR DESCRIPTION
pull request which replaces the staled pull requests: https://github.com/MathCancer/PhysiCell/pull/344, https://github.com/MathCancer/PhysiCell/pull/298, https://github.com/MathCancer/PhysiCell/pull/264, https://github.com/MathCancer/PhysiCell/pull/250 and https://github.com/MathCancer/PhysiCell/pull/232.

These changes are the bare minimum needed to reload a setting xml file, to be able to run in the same runtime multiple consecutive episodes of a physicell run.

This pull request is compatible with physicell version 1.14.1 and keeps the changes to the existing code bases as small as possible. 
Default settings were chosen so that the current model not will break through these changes.

The code was extensively tested here: https://github.com/elmbeech/episode 