### PR TITLE
re-round template project cycle durations

### DIFF
--- a/sample_projects/template/config/PhysiCell_settings.xml
+++ b/sample_projects/template/config/PhysiCell_settings.xml
@@ -88,10 +88,10 @@
             <phenotype>
                 <cycle code="6" name="Flow cytometry model (separated)">
                     <phase_durations units="min">
-                        <duration index="0" fixed_duration="false">300.030003</duration>
-                        <duration index="1" fixed_duration="true">480.076812</duration>
-                        <duration index="2" fixed_duration="true">239.980802</duration>
-                        <duration index="3" fixed_duration="true">59.998800</duration>
+                        <duration index="0" fixed_duration="false">300.0</duration>
+                        <duration index="1" fixed_duration="true">480.0</duration>
+                        <duration index="2" fixed_duration="true">240.0</duration>
+                        <duration index="3" fixed_duration="true">60.0</duration>
                     </phase_durations>
                 </cycle>
                 <death>


### PR DESCRIPTION
for a brief second, studio was parsing cycle durations into rates and back, truncating to 5 decimals at each step. studio no longer double-converts cycle durations.
the template project was updated to 1.14.1 in this window and the cycle durations go weird decimals. This restores them