### PR TITLE
more robust macro to check for windows

### DIFF
--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -349,7 +349,7 @@ bool create_directories(const std::string &path)
 
 bool create_directory(const std::string &path)
 {
-#if defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(_WIN32)
 	bool success = mkdir(path.c_str()) == 0;
 #else
 	bool success = mkdir(path.c_str(), 0755) == 0;


### PR DESCRIPTION
When creating output directories, currently use `__MINGW32__` and `__MINGW64__` to check if compiling on Windows, but this only checks if using particular windows compilers. they are the ones we tell users to use, but switching to `_W32` will be more robust.