### PR TITLE
fix 'phagocytosis of __' synonym

### DIFF
--- a/core/PhysiCell_signal_behavior.cpp
+++ b/core/PhysiCell_signal_behavior.cpp
@@ -484,7 +484,7 @@ void setup_signal_behavior_dictionaries( void )
 		behavior_to_int[temp] = map_index; 
 
 		// synonym 
-		temp = "phagocytosis of " + std::to_string(pCD->type); 
+		temp = "phagocytosis of " + pCD->name; 
 		behavior_to_int[temp] = map_index; 
 	}
 


### PR DESCRIPTION
responsive to #355 

previously used the cell type ID (an integer) to fill in the __. Want to use the name of the cel type though.