### PR TITLE
msys2 package list clean out and brew gcc update to v14.

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -82,7 +82,7 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-x86_64-gcc make mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ffmpeg unzip zip git mingw-w64-x86_64-python-zstandard mingw-w64-x86_64-ca-certificates
+        install: mingw-w64-ucrt-x86_64-gcc make mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-ffmpeg unzip zip git mingw-w64-ucrt-x86_64-python-zstandard mingw-w64-ucrt-x86_64-ca-certificates
 
     - name: Build ${{ matrix.projects.name }} project
       run: |

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -82,7 +82,7 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-x86_64-binutils mingw-w64-x86_64-gcc mingw-w64-x86_64-headers-git mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-lapack mingw-w64-x86_64-openblas mingw-w64-x86_64-libxml2 mingw-w64-x86_64-bzip2 mingw-w64-x86_64-python mingw-w64-x86_64-python-zstandard mingw-w64-x86_64-python-cffi make bison flex mingw-w64-x86_64-ca-certificates
+        install: mingw-w64-x86_64-gcc make mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ffmpeg unzip zip git mingw-w64-x86_64-python-zstandard mingw-w64-x86_64-ca-certificates
 
     - name: Build ${{ matrix.projects.name }} project
       run: |
@@ -134,10 +134,10 @@ jobs:
 
     - name: Install dependencies
       run : |
-        if ! brew list gcc@13 &>/dev/null; then
-          brew install gcc@13
+        if ! brew list gcc@14 &>/dev/null; then
+          brew install gcc@14
         else
-          echo "gcc@13 is already installed."
+          echo "gcc@14 is already installed."
         fi
       
     - name: Build ${{ matrix.projects.name }} project
@@ -146,7 +146,7 @@ jobs:
         make ${{ matrix.projects.project }}
         make clean
         ${{ matrix.projects.extra_run }}
-        make PHYSICELL_CPP=g++-13 static
+        make PHYSICELL_CPP=g++-14 static
         cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos13
 
     - name: Caching produced project binary 
@@ -184,10 +184,10 @@ jobs:
 
     - name: Install dependencies
       run : |
-        if ! brew list gcc@13 &>/dev/null; then
-          brew install gcc@13
+        if ! brew list gcc@14 &>/dev/null; then
+          brew install gcc@14
         else
-          echo "gcc@13 is already installed."
+          echo "gcc@14 is already installed."
         fi
       
     - name: Build ${{ matrix.projects.name }} project
@@ -196,7 +196,7 @@ jobs:
         make ${{ matrix.projects.project }}
         make clean
         ${{ matrix.projects.extra_run }}
-        make PHYSICELL_CPP=g++-13 static
+        make PHYSICELL_CPP=g++-14 static
         cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macosm1
    
     - name: Caching produced project binary 

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -82,7 +82,7 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-ucrt-x86_64-gcc make mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-ffmpeg unzip zip git mingw-w64-ucrt-x86_64-python-zstandard mingw-w64-ucrt-x86_64-ca-certificates
+        install: mingw-w64-x86_64-gcc make mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ffmpeg unzip zip git mingw-w64-x86_64-python-zstandard mingw-w64-x86_64-ca-certificates
 
     - name: Build ${{ matrix.projects.name }} project
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-ucrt-x86_64-gcc make mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-ffmpeg unzip zip git mingw-w64-ucrt-x86_64-ca-certificates mingw-w64-ucrt-x86_64-diffutils
+        install: mingw-w64-x86_64-gcc make mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ffmpeg unzip zip git mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-diffutils
 
     - name: Build ${{ matrix.projects.name }} project 
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-x86_64-gcc make mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ffmpeg unzip zip git mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-diffutils
+        install: mingw-w64-ucrt-x86_64-gcc make mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-ffmpeg unzip zip git mingw-w64-ucrt-x86_64-ca-certificates mingw-w64-ucrt-x86_64-diffutils
 
     - name: Build ${{ matrix.projects.name }} project 
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         os: [
           {name: "Ubuntu", os: "ubuntu-latest", shell: "bash", compiler: "g++"},
-          {name: "MacOS 13", os: "macos-13", shell: "bash", compiler: "g++-12"},
-          {name: "MacOS 14 (M1)", os: "macos-14", shell: "bash", compiler: "g++-13"},
+          {name: "MacOS 13", os: "macos-13", shell: "bash", compiler: "g++-14"},
+          {name: "MacOS 14 (M1)", os: "macos-14", shell: "bash", compiler: "g++-14"},
           {name: "Windows", os: "windows-latest", shell: "msys2", compiler: "g++"},
         ]
         projects: [
@@ -52,8 +52,8 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-x86_64-binutils mingw-w64-x86_64-gcc mingw-w64-x86_64-headers-git mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-lapack mingw-w64-x86_64-openblas mingw-w64-x86_64-libxml2 mingw-w64-x86_64-bzip2 mingw-w64-x86_64-python mingw-w64-x86_64-python-zstandard mingw-w64-x86_64-python-cffi make bison flex mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-diffutils
-    
+        install: mingw-w64-x86_64-gcc make mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ffmpeg unzip zip git mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-diffutils
+
     - name: Build ${{ matrix.projects.name }} project 
       run: |
         make data-cleanup && make ${{ matrix.projects.project }} && make PHYSICELL_CPP=${{ matrix.os.compiler }} PROGRAM_NAME=${{ matrix.projects.binary }}


### PR DESCRIPTION
lately i was writing new physicell installation manuals for the power users.
thereby, i cleaned out the msys2 package list.
additionally, i noticed that brew nowadays ships with gcc version 14.
this is an update to the workflow files from what i learned on the way.