### PR TITLE
protect `pre_update_intracellular` from changes made in `post_update_intracellular`

### DIFF
--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -304,16 +304,17 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 
 void Cell_Container::update_all_cells_intracellular( void )
 {
-	bool anything_to_update = false;
+	bool anything_to_update = false; // Use a simple boolean for reduction
 	std::vector<bool> ready_to_update_intracellular = std::vector<bool>( (*all_cells).size(), false );
-	#pragma omp parallel for 
+
+	#pragma omp parallel for reduction(||:anything_to_update)
 	for( int i=0; i < (*all_cells).size(); i++ )
 	{
 		if( (*all_cells)[i]->is_out_of_domain == false ) {
 			if( (*all_cells)[i]->phenotype.intracellular != NULL  && (*all_cells)[i]->phenotype.intracellular->need_update())
 			{
 				ready_to_update_intracellular[i] = true;
-				anything_to_update = true;
+				anything_to_update = true; // Set to true if any cell needs an update
 				if ((*all_cells)[i]->functions.pre_update_intracellular != NULL)
 				{
 					(*all_cells)[i]->functions.pre_update_intracellular((*all_cells)[i], (*all_cells)[i]->phenotype, diffusion_dt);
@@ -324,7 +325,7 @@ void Cell_Container::update_all_cells_intracellular( void )
 
 	if (!anything_to_update)
 	{ return; }
-	
+
 	#pragma omp parallel for
 	for ( int i=0; i < (*all_cells).size(); i++ )
 	{

--- a/core/PhysiCell_cell_container.cpp
+++ b/core/PhysiCell_cell_container.cpp
@@ -140,24 +140,8 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 	static double mechanics_dt_tolerance = 0.001 * mechanics_dt_; 
 
 	// intracellular update. called for every diffusion_dt, but actually depends on the intracellular_dt of each cell (as it can be noisy)
-
-	#pragma omp parallel for 
-	for( int i=0; i < (*all_cells).size(); i++ )
-	{
-		if( (*all_cells)[i]->is_out_of_domain == false && initialzed ) {
-
-			if( (*all_cells)[i]->phenotype.intracellular != NULL  && (*all_cells)[i]->phenotype.intracellular->need_update())
-			{
-				if ((*all_cells)[i]->functions.pre_update_intracellular != NULL)
-					(*all_cells)[i]->functions.pre_update_intracellular( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
-
-				(*all_cells)[i]->phenotype.intracellular->update( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
-
-				if ((*all_cells)[i]->functions.post_update_intracellular != NULL)
-					(*all_cells)[i]->functions.post_update_intracellular( (*all_cells)[i], (*all_cells)[i]->phenotype , diffusion_dt_ );
-			}
-		}
-	}
+	if (initialzed)
+	{ update_all_cells_intracellular(); }
 	
 	if( time_since_last_cycle > phenotype_dt_ - 0.5 * diffusion_dt_ || !initialzed )
 	{
@@ -316,6 +300,48 @@ void Cell_Container::update_all_cells(double t, double phenotype_dt_ , double me
 	
 	initialzed=true;
 	return;
+}
+
+void Cell_Container::update_all_cells_intracellular( void )
+{
+	bool anything_to_update = false;
+	std::vector<bool> ready_to_update_intracellular = std::vector<bool>( (*all_cells).size(), false );
+	#pragma omp parallel for 
+	for( int i=0; i < (*all_cells).size(); i++ )
+	{
+		if( (*all_cells)[i]->is_out_of_domain == false ) {
+			if( (*all_cells)[i]->phenotype.intracellular != NULL  && (*all_cells)[i]->phenotype.intracellular->need_update())
+			{
+				ready_to_update_intracellular[i] = true;
+				anything_to_update = true;
+				if ((*all_cells)[i]->functions.pre_update_intracellular != NULL)
+				{
+					(*all_cells)[i]->functions.pre_update_intracellular((*all_cells)[i], (*all_cells)[i]->phenotype, diffusion_dt);
+				}
+			}
+		}
+	}
+
+	if (!anything_to_update)
+	{ return; }
+	
+	#pragma omp parallel for
+	for ( int i=0; i < (*all_cells).size(); i++ )
+	{
+		if (ready_to_update_intracellular[i])
+		{
+			(*all_cells)[i]->phenotype.intracellular->update((*all_cells)[i], (*all_cells)[i]->phenotype, diffusion_dt);
+		}
+	}
+	
+	#pragma omp parallel for
+	for ( int i=0; i < (*all_cells).size(); i++ )
+	{
+		if (ready_to_update_intracellular[i] && (*all_cells)[i]->functions.post_update_intracellular != NULL)
+		{
+			(*all_cells)[i]->functions.post_update_intracellular((*all_cells)[i], (*all_cells)[i]->phenotype, diffusion_dt);
+		}
+	}
 }
 
 void Cell_Container::register_agent( Cell* agent )

--- a/core/PhysiCell_cell_container.h
+++ b/core/PhysiCell_cell_container.h
@@ -104,7 +104,9 @@ class Cell_Container : public BioFVM::Agent_Container
 	void update_all_cells(double t);
 	void update_all_cells(double t, double dt);
 	void update_all_cells(double t, double phenotype_dt, double mechanics_dt);
-	void update_all_cells(double t, double phenotype_dt, double mechanics_dt, double diffusion_dt ); 
+	void update_all_cells(double t, double phenotype_dt, double mechanics_dt, double diffusion_dt );
+
+	void update_all_cells_intracellular( void );
 
 	void register_agent( Cell* agent );
 	void add_agent_to_outer_voxel(Cell* agent);


### PR DESCRIPTION
In models with both `pre_update_intracellular` and `post_update_intracellular` functions, it is currently possible for some cells to complete their post-update before other cells begin their pre-update. If the post-update modifies values in those cells that others use in the pre-update function (for example, surface-bound ligand expression), the pre-update function will use the incorrect values to update. This PR addresses this by performing the intracellular update as follows:
1. Loop over all cells
  a. Determine which are ready for intracellular updates
  b. For these, do their `pre_update_intracellular` (if defined)
2. If no updates found, return from `update_all_cells_intracellular`
3. Loop over all cells ready for update and call their `update` function
4. Loop over all cells ready for update and call their `post_intracellular_update` (if defined)

## Commit comments
- first do all pre updates, then all updates, then all post updates
- this ensures that any changes manifested in updates/post-updates are not immediately visible to the pre-updates of other cells
- with the more verbose logic controlling intracellular updates, make a separate function to handle it
    - in that function, encode directly dependence on `diffusion_dt` rather than the argument `diffusion_dt_`
    - `initialzed` used to determine when to call `intracellular` rather than passed in
    - if after first looping over all cells, none were found to require intracellular updates, then return early