### PR TITLE
update intracellular in first time step

### DIFF
--- a/core/PhysiCell_cell_container.h
+++ b/core/PhysiCell_cell_container.h
@@ -84,7 +84,6 @@ class Cell_Container : public BioFVM::Agent_Container
 	std::vector<Cell*> cells_ready_to_divide; // the index of agents ready to divide
 	std::vector<Cell*> cells_ready_to_die;
 	int boundary_condition_for_pushed_out_agents; 	// what to do with pushed out cells
-	bool initialzed = false;
 	
  public:
 	BioFVM::Cartesian_Mesh underlying_mesh;


### PR DESCRIPTION
Low priority PR that fixes bug causing intracellular updates to skip the first diffusion time step at t=0. I don't believe that PhysiBoSS or PhysiCelldFBA require this step to be skipped, but please inform if it is necessary :) 

It is possible that rules that depend on variables expected to be set in a `post_intracellular_update` function could receive unexpected inputs causing unintended behavior in the first `advance_bundled_phenotype_functions` and subsequent mechanics updates.

- this change allows intracellular updates to occur in the first diffusion step
- before, they had to wait one diffusion step to update (if there's a reason for this, it's lost on me)
- removed need for `initialzed` [sic] field in `Cell_Container` class
- also make easier-to-parse logic and variable names for when to update phenotype and mechanics