### PR TITLE
when asym divs probs sum to >1, exit with msg

### DIFF
--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1382,7 +1382,8 @@ void standard_asymmetric_division_function( Cell* pCell_parent, Cell* pCell_daug
 		double sym_div_prob = pCell_parent->phenotype.cycle.asymmetric_division.asymmetric_division_probabilities[pCell_parent->type] + 1.0 - total;
 		if (sym_div_prob < 0.0)
 		{ 
-			throw std::runtime_error("Error: Asymmetric division probabilities for " + pCD_parent->name + " sum to greater than 1.0 and cannot be normalized.");
+			std::cerr << "Error: Asymmetric division probabilities for " + pCD_parent->name + " sum to greater than 1.0 and cannot be normalized." << std::endl;
+			exit(-1);
 		}
 		pCell_parent->phenotype.cycle.asymmetric_division.asymmetric_division_probabilities[pCell_parent->type] = sym_div_prob;
 		pCell_daughter->phenotype.cycle.asymmetric_division.asymmetric_division_probabilities[pCell_daughter->type] = sym_div_prob;


### PR DESCRIPTION
@heberlr first identified this behavior and a discussion led to opening #347. While better handling of thrown exceptions would be an improvement, for now have this error behave like all others and `exit(-1)`.

previously, used `throw` but the standard `main.cpp` catches the exception and still exits with 0