### PR TITLE
simplified dc functions

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -232,6 +232,11 @@ void Microenvironment::fix_substrate_at_voxel( int substrate_index, int voxel_in
 
 void Microenvironment::fix_substrates_at_voxel( int voxel_index , std::vector<double>& new_values )
 {
+	if (new_values.size() != dirichlet_value_vectors[voxel_index].size())
+	{
+		std::cerr << "Error: Incorrect number of values passed in to fix_substrates_at_voxel. Expected " << dirichlet_value_vectors[voxel_index].size() << " values, but got " << new_values.size() << "." << std::endl;
+		return;
+	}
 	dirichlet_value_vectors[voxel_index] = new_values;
 	return fix_substrates_at_voxel( voxel_index );
 }
@@ -258,7 +263,7 @@ void Microenvironment::fix_substrate_at_voxels( int substrate_index, std::vector
 {
 	if (new_values.size() != voxel_indices.size())
 	{
-		std::cerr << "Error: new_values size does not match voxel_indices size in Microenvironment::fix_substrate_at_voxels" << std::endl;
+		std::cerr << "Error: new_values size (" << new_values.size() << ") does not match voxel_indices size (" << voxel_indices.size() << ") in Microenvironment::fix_substrate_at_voxels" << std::endl;
 		return;
 	}
 	for( unsigned int i=0 ; i < voxel_indices.size() ; i++ )
@@ -730,7 +735,7 @@ int Microenvironment::find_existing_density_index( std::string name )
 	int i = find_density_index( name );
 	if( i != -1 )
 	{ return i; }
-	std::cout << "Error: density named " << name << " not found." << std::endl;
+	std::cerr << "Error: density named " << name << " not found." << std::endl;
 	exit(-1); 
 }
 

--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -235,7 +235,7 @@ void Microenvironment::fix_substrates_at_voxel( int voxel_index , std::vector<do
 	if (new_values.size() != dirichlet_value_vectors[voxel_index].size())
 	{
 		std::cerr << "Error: Incorrect number of values passed in to fix_substrates_at_voxel. Expected " << dirichlet_value_vectors[voxel_index].size() << " values, but got " << new_values.size() << "." << std::endl;
-		return;
+		exit(-1);
 	}
 	dirichlet_value_vectors[voxel_index] = new_values;
 	return fix_substrates_at_voxel( voxel_index );
@@ -264,7 +264,7 @@ void Microenvironment::fix_substrate_at_voxels( int substrate_index, std::vector
 	if (new_values.size() != voxel_indices.size())
 	{
 		std::cerr << "Error: new_values size (" << new_values.size() << ") does not match voxel_indices size (" << voxel_indices.size() << ") in Microenvironment::fix_substrate_at_voxels" << std::endl;
-		return;
+		exit(-1);
 	}
 	for( unsigned int i=0 ; i < voxel_indices.size() ; i++ )
 	{
@@ -339,7 +339,7 @@ void Microenvironment::unfix_substrates_at_voxel( int voxel_index )
 
 void Microenvironment::sync_substrate_dirichlet_activation( int substrate_index )
 {
-	for (auto voxel_activation_vector : dirichlet_activation_vectors)
+	for (const auto& voxel_activation_vector : dirichlet_activation_vectors)
 	{
 		if (voxel_activation_vector[substrate_index])
 		{

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -241,8 +241,8 @@ class Microenvironment
 	void fix_substrate_at_voxels( int substrate_index, std::vector<int>& voxel_indices, double new_value );
 	void fix_substrate_at_voxels( int substrate_index, std::vector<int>& voxel_indices, std::vector<double>& new_values );
 	void fix_substrate_at_voxels( int substrate_index, std::vector<int>& voxel_indices );
-	void fix_substrates_at_voxel( int voxel_ind, std::vector<double>& new_values );
-	void fix_substrates_at_voxel( int voxel_ind );
+	void fix_substrates_at_voxel( int voxel_index, std::vector<double>& new_values );
+	void fix_substrates_at_voxel( int voxel_index );
 
 	void unfix_substrate_at_voxel( std::string substrate, int voxel_index );
 	void unfix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices );

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -121,18 +121,10 @@ class Microenvironment
 	
 	// on "resize density" type operations, need to extend all of these 
 	
-	/*
-	std::vector<int> dirichlet_indices; 
 	std::vector< std::vector<double> > dirichlet_value_vectors; 
-	std::vector<bool> dirichlet_node_map; 
-	*/
-	std::vector< std::vector<double> > dirichlet_value_vectors; 
-	std::vector<bool> dirichlet_activation_vector; 
 	
-	/* new in Version 1.7.0 -- activation vectors can be specified 
-	   on a voxel-by-voxel basis */ 
-	   
 	std::vector< std::vector<bool> > dirichlet_activation_vectors; 
+	std::vector<bool> dirichlet_activation_vector; // whether a given substrate has a DC set somewhere
 	
  public:
 	
@@ -190,6 +182,7 @@ class Microenvironment
 	void set_density( int index , std::string name , std::string units , double diffusion_constant , double decay_rate ); 
 
 	int find_density_index( std::string name ); 
+	int find_existing_density_index( std::string name ); 
 	
 	int voxel_index( int i, int j, int k ); 
 	std::vector<unsigned int> cartesian_indices( int n ); 
@@ -237,7 +230,28 @@ class Microenvironment
 	void simulate_cell_sources_and_sinks( double dt ); 
 	
 	void display_information( std::ostream& os ); 
-	
+
+	void fix_substrate_at_voxel( std::string substrate, int voxel_index, double new_value );
+	void fix_substrate_at_voxel( std::string substrate, int voxel_index );
+	void fix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices, double new_value );
+	void fix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices, std::vector<double>& new_values );
+	void fix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices );
+	void fix_substrate_at_voxel( int substrate_index, int voxel_index, double new_value );
+	void fix_substrate_at_voxel( int substrate_index, int voxel_index );
+	void fix_substrate_at_voxels( int substrate_index, std::vector<int>& voxel_indices, double new_value );
+	void fix_substrate_at_voxels( int substrate_index, std::vector<int>& voxel_indices, std::vector<double>& new_values );
+	void fix_substrate_at_voxels( int substrate_index, std::vector<int>& voxel_indices );
+	void fix_substrates_at_voxel( int voxel_ind, std::vector<double>& new_values );
+	void fix_substrates_at_voxel( int voxel_ind );
+
+	void unfix_substrate_at_voxel( std::string substrate, int voxel_index );
+	void unfix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices );
+	void unfix_substrate_at_voxel( int substrate_index, int voxel_index );
+	void unfix_substrate_at_voxels( int substrate_index, std::vector<int>& voxel_indices );
+	void unfix_substrates_at_voxel( int voxel_index );
+
+	void sync_substrate_dirichlet_activation( int substrate_index );
+
 	void add_dirichlet_node( int voxel_index, std::vector<double>& value ); 
 	void update_dirichlet_node( int voxel_index , std::vector<double>& new_value ); 
 	void update_dirichlet_node( int voxel_index , int substrate_index , double new_value );

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -231,6 +231,7 @@ class Microenvironment
 	
 	void display_information( std::ostream& os ); 
 
+	// Dirichlet setters/clearers: invalid input (unknown substrate name, mismatched vector sizes) is fatal
 	void fix_substrate_at_voxel( std::string substrate, int voxel_index, double new_value );
 	void fix_substrate_at_voxel( std::string substrate, int voxel_index );
 	void fix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices, double new_value );


### PR DESCRIPTION
The current API for the Dirichlet nodes is inconsistent and confusing (See #214). To simplify the API for users, I have created two functions that handle all the DC logic in a straightforward, intuitive, and consistent manner. Several variants are included for those looking to fully optimize these calls (though unless the model is changing DC activations nearly every `diffusion_dt`, I doubt they matter enough to be noticed). The old API, using verbs `add`, `update`, and `remove` remain so that we can preserve backwards compatibility. The new API uses `fix` and `unfix`.

## New API
To fix a substrate at a voxel, i.e., set a DC condition, users can call
```cpp
fix_substrate_at_voxel(std::string substrate_name, int voxel_index[, double new_value]);
```
where `new_value` is optional[^1].

To unfix a substrate at a voxel:
```cpp
unfix_substrate_at_voxel(std::string substrate_name, int voxel_index);
```
In these and all cases that follow, passing in `int substrate_index` in place of `substrate_name` is allowed.

## Handling Boolean activations
The confusing part of the previous API was the inconsistency of updating the Booleans that tracked which `(voxel, substrate)`, `voxel`, and `substrate` had active DCs. This new proposed API handles these consistently:
- `dirichlet_activation_vectors` maintains the lowest level detail where `dirichlet_activation_vectors[voxel_index][substrate_index]` indicates whether that substrate is has a DC at that voxel
- `dirichlet_activation_vector` maintains whether a substrate has a DC anywher and is accessed by `dirichlet_activation_vector[substrate_index]`
- `voxel.is_Dirichlet` maintains whether any substrate has a DC at the given voxel

## Convenience API to (possibly) save time
Maintaining the above Boolean activation values can incur unnecessary computational expense if `fix`-ing or `unfix`-ing many substrates/voxels at once. For users who wish to save even these scraps of time, the following are implemented to update the Boolean variables after accounting for all the changes:
```cpp
fix_substrate_at_voxels(std::string substrate, std::vector<int>& voxel_indices, std::vector<double>& new_values); // see below for alternative signatures
unfix_substrate_at_voxels(std::string substrate, std::vector<int>& voxel_indices);
```

## Fix with flexible value update
Anticipating users turning "back on" a DC, the `fix_...` calls do not require passing in a value. In this case, whatever value was in `dirichlet_value_vectors[voxel_index][substrate_index]` remains.
```cpp
fix_substrate_at_voxel( std::string substrate, int voxel_index );
fix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices );
```
Similarly, if fix multiple voxels at once with uniform DCs, just the one value can be passed:
```cpp
fix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices, double new_value );
```

## All substrates in a voxel at once
To support changing all substrates in a voxel at once, the following three functions are provided:
```cpp
fix_substrates_at_voxel( int voxel_ind, std::vector<double>& new_values );
fix_substrates_at_voxel( int voxel_ind );
unfix_substrates_at_voxel( int voxel_index );
```

[^1]: It does not use an optional arg, but just has two implementations