### PR TITLE
hotfix finding copying input files to output

### DIFF
--- a/core/PhysiCell_utilities.cpp
+++ b/core/PhysiCell_utilities.cpp
@@ -370,7 +370,7 @@ void copy_file_to_output(std::string filename)
 	std::cout << "Copying " << filename << " to output folder." << std::endl;
 	// copy the file to the output folder
 	std::string basename = filename;
-	size_t found = basename.find_last_of("/"); // find the end of the path
+	size_t found = basename.find_last_of("/\\");
 	if (found != std::string::npos)
 	{
 		basename = basename.substr(found + 1);


### PR DESCRIPTION
We had only looked for the Linux/MacOS pathsep (`'/'`) to identify the basename for the file being copied to the output folder. If a user set this with a Windows path, it would lead to the file not being copied.