### PR TITLE
standardize file copy to output

### DIFF
--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -1934,8 +1934,10 @@ void parse_rules_from_pugixml( void )
 			if( done == false )
 			{ std::cout << "\tWarning: Ruleset had unknown format (" << format << "). Skipping!" << std::endl; }
 			else
-			{ copy_file_to_output( input_filename ); }
-
+			{
+				std::string default_basename = "cell_rules.csv";
+				copy_file_to_output(input_filename, default_basename);
+			}
 		}
 		else
 		{ std::cout << "\tRuleset disabled ... " << std::endl; }

--- a/core/PhysiCell_utilities.cpp
+++ b/core/PhysiCell_utilities.cpp
@@ -365,7 +365,7 @@ int choose_event( std::vector<double>& probabilities )
 	return probabilities.size(); 
 }
 
-void copy_file_to_output(std::string filename)
+void copy_file_to_output(const std::string &filename, const std::string &default_basename)
 {
 	std::cout << "Copying " << filename << " to output folder." << std::endl;
 	// copy the file to the output folder
@@ -381,8 +381,17 @@ void copy_file_to_output(std::string filename)
 	// copy filename to output_filename
 	char copy_command[1024];
 	sprintf(copy_command, "cp %s %s", filename.c_str(), output_filename.c_str());
-	std::cout << "Copy command: " << copy_command << std::endl;
 	(void)system(copy_command); // make it explicit that we are ignoring the return value
+
+	if (default_basename.empty() || default_basename == basename) {
+		return;
+	}
+
+	// copy the file to the output folder with the default basename
+	std::string default_output_filename = PhysiCell_settings.folder + "/" + default_basename;
+	sprintf(copy_command, "cp %s %s", filename.c_str(), default_output_filename.c_str());
+	(void)system(copy_command); // make it explicit that we are ignoring the return value
+	return;
 }
 
 };

--- a/core/PhysiCell_utilities.cpp
+++ b/core/PhysiCell_utilities.cpp
@@ -381,7 +381,11 @@ void copy_file_to_output(const std::string &filename, const std::string &default
 	// copy filename to output_filename
 	char copy_command[1024];
 	sprintf(copy_command, "cp %s %s", filename.c_str(), output_filename.c_str());
-	(void)system(copy_command); // make it explicit that we are ignoring the return value
+
+	int ret_code = system(copy_command);
+	if (ret_code != 0) {
+		std::cerr << "Error: Failed to execute command: " << copy_command << std::endl;
+	}
 
 	if (default_basename.empty() || default_basename == basename) {
 		return;
@@ -390,7 +394,11 @@ void copy_file_to_output(const std::string &filename, const std::string &default
 	// copy the file to the output folder with the default basename
 	std::string default_output_filename = PhysiCell_settings.folder + "/" + default_basename;
 	sprintf(copy_command, "cp %s %s", filename.c_str(), default_output_filename.c_str());
-	(void)system(copy_command); // make it explicit that we are ignoring the return value
+
+	ret_code = system(copy_command);
+	if (ret_code != 0) {
+		std::cerr << "Error: Failed to execute command: " << copy_command << std::endl;
+	}
 	return;
 }
 

--- a/core/PhysiCell_utilities.h
+++ b/core/PhysiCell_utilities.h
@@ -111,7 +111,7 @@ void add_software_citation( std::string name , std::string version, std::string 
 
 int choose_event( std::vector<double>& probabilities ); 
 
-void copy_file_to_output( std::string filename );
+void copy_file_to_output(const std::string &filename, const std::string &default_basename = "");
 };
 
 #endif

--- a/modules/PhysiCell_geometry.cpp
+++ b/modules/PhysiCell_geometry.cpp
@@ -395,7 +395,8 @@ bool load_cells_from_pugixml( pugi::xml_node root )
 		exit(-1);
 	}
 
-	copy_file_to_output(input_filename);
+	std::string default_basename = "cells.csv";
+	copy_file_to_output(input_filename, default_basename);
 	return true; 
 }
 

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -119,7 +119,8 @@ bool load_PhysiCell_config_file( std::string filename )
 
 	create_output_directory( PhysiCell_settings.folder );
 
-	copy_file_to_output( filename );
+	std::string default_basename = "PhysiCell_settings.xml";
+	copy_file_to_output( filename, default_basename ); // copy the settings file to the output folder
 
 	return true;
 }
@@ -963,7 +964,8 @@ bool setup_microenvironment_from_XML( pugi::xml_node root_node )
 			default_microenvironment_options.initial_condition_file_type = node.attribute("type").as_string();
 			default_microenvironment_options.initial_condition_file = xml_get_string_value(node, "filename");
 
-			copy_file_to_output(default_microenvironment_options.initial_condition_file);
+			std::string default_basename = default_microenvironment_options.initial_condition_file_type == "matlab" ? "substrates.mat" : "substrates.csv"; // when loading the file, we check that it is one of these two types
+			copy_file_to_output(default_microenvironment_options.initial_condition_file, default_basename);
 		}
 	}
 

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -102,9 +102,9 @@ bool load_PhysiCell_config_file( std::string filename )
 	if (!read_PhysiCell_config_file( filename ))
 	{ return false; }
 
-	PhysiCell_settings.read_from_pugixml(); 
+	PhysiCell_settings.read_from_pugixml();
 	
-	// now read the microenvironment (optional) 
+	// now read the microenvironment (optional)
 	
 	if( !setup_microenvironment_from_XML( physicell_config_root ) )
 	{
@@ -119,7 +119,9 @@ bool load_PhysiCell_config_file( std::string filename )
 
 	create_output_directory( PhysiCell_settings.folder );
 
-	return true; 	
+	copy_file_to_output( filename );
+
+	return true;
 }
 
 PhysiCell_Settings::PhysiCell_Settings()

--- a/sample_projects/asymmetric_division/main.cpp
+++ b/sample_projects/asymmetric_division/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/biorobots/main.cpp
+++ b/sample_projects/biorobots/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/cancer_biorobots/main.cpp
+++ b/sample_projects/cancer_biorobots/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/cancer_immune/main-cancer_immune_3D.cpp
+++ b/sample_projects/cancer_immune/main-cancer_immune_3D.cpp
@@ -88,22 +88,16 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	
 	bool XML_status = false; 
-	char copy_command [1024]; 
 	if( argc > 1 )
 	{
 		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/custom_division/main.cpp
+++ b/sample_projects/custom_division/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/heterogeneity/main.cpp
+++ b/sample_projects/heterogeneity/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/immune_function/main.cpp
+++ b/sample_projects/immune_function/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/interactions/main.cpp
+++ b/sample_projects/interactions/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/mechano/main.cpp
+++ b/sample_projects/mechano/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/physimess/main.cpp
+++ b/sample_projects/physimess/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/pred_prey_farmer/main.cpp
+++ b/sample_projects/pred_prey_farmer/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/rules_sample/main.cpp
+++ b/sample_projects/rules_sample/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/template/main.cpp
+++ b/sample_projects/template/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/virus_macrophage/main.cpp
+++ b/sample_projects/virus_macrophage/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects/worm/main.cpp
+++ b/sample_projects/worm/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects_intracellular/boolean/cancer_invasion/main.cpp
+++ b/sample_projects_intracellular/boolean/cancer_invasion/main.cpp
@@ -88,30 +88,20 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	char copy_command_2 [1024];
 	if( argc > 1 )
 	{
 		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argv[1] , PhysiCell_settings.folder.c_str() ); 
 		sprintf( copy_command_2 , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		system( copy_command_2 );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
-	
-	if ( argc > 1 )
-	{
-		system( copy_command_2 );
-	}
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects_intracellular/boolean/template_BM/main.cpp
+++ b/sample_projects_intracellular/boolean/template_BM/main.cpp
@@ -88,23 +88,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
 		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argv[1] , PhysiCell_settings.folder.c_str() ); 
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/sample_projects_intracellular/boolean/tutorial/main.cpp
+++ b/sample_projects_intracellular/boolean/tutorial/main.cpp
@@ -88,31 +88,21 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	char copy_command_2 [1024]; 
 	if( argc > 1 )
 	{
 		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argv[1] , PhysiCell_settings.folder.c_str() ); 
 		sprintf( copy_command_2 , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		system( copy_command_2 ); 
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
 	
-	// copy config file to output directry 
-	system( copy_command ); 
-	
-	if( argc > 1 )
-	{
-		system( copy_command_2 ); 
-	}
-		
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 	

--- a/sample_projects_intracellular/fba/cancer_metabolism/main.cpp
+++ b/sample_projects_intracellular/fba/cancer_metabolism/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/unit_tests/custom_DCs_2substrates/main.cpp
+++ b/unit_tests/custom_DCs_2substrates/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);

--- a/unit_tests/custom_voxel_values/main.cpp
+++ b/unit_tests/custom_voxel_values/main.cpp
@@ -87,23 +87,17 @@ int main( int argc, char* argv[] )
 {
 	// load and parse settings file(s)
 	
-	bool XML_status = false; 
-	char copy_command [1024]; 
+	bool XML_status = false;
 	if( argc > 1 )
 	{
-		XML_status = load_PhysiCell_config_file( argv[1] ); 
-		sprintf( copy_command , "cp %s %s" , argv[1] , PhysiCell_settings.folder.c_str() ); 
+		XML_status = load_PhysiCell_config_file( argv[1] );
 	}
 	else
 	{
 		XML_status = load_PhysiCell_config_file( "./config/PhysiCell_settings.xml" );
-		sprintf( copy_command , "cp ./config/PhysiCell_settings.xml %s" , PhysiCell_settings.folder.c_str() ); 
 	}
 	if( !XML_status )
 	{ exit(-1); }
-	
-	// copy config file to output directry 
-	system( copy_command ); 
 	
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);


### PR DESCRIPTION
Standardize how all files are copied to output. This serves several purposes:
- ensures that the config file is copied
  -  previously handled in user-defined `main.cpp`
  - now done in core as we had been doing with rules, ic cells, and ic substrates
- optional `default_basename` argument in `copy_file_to_output` ensures standard file naming in output
  - ensures downstream tools can find the appropriate files, e.g. pcdl
  - does result in duplicate files in the output if the user-supplied name differs from the default base name, but this is minimal compared to the simulation data

Note: If a user retains the copy command in their `main.cpp`, this will just mean it is copied twice which will not cause errors.