### PR TITLE
remove checks for edge cases in boundary repulsion

### DIFF
--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1097,64 +1097,8 @@ double distance_to_domain_edge(Cell* pCell, Phenotype& phenotype, double dummy)
 			min_distance = temp_distance; 
 			nearest_boundary = 5; 
 		}			
-		
-		// check for 3D exceptions 
-		
-		// lines 
-		if( fabs( (pCell->position[0]) - (pCell->position[1]) ) < tolerance && 
-			fabs( (pCell->position[1]) - (pCell->position[2]) ) < tolerance && 
-			fabs( (pCell->position[0]) - (pCell->position[2]) ) < tolerance )
-		{
-			if( pCell->position[0] > 0 )
-			{
-				if( pCell->position[0] > 0 && pCell->position[1] > 0 )
-				{ pCell->displacement = { -one_over_sqrt_3 , -one_over_sqrt_3 , -one_over_sqrt_3 }; }
-				if( pCell->position[0] < 0 && pCell->position[1] > 0 )
-				{ pCell->displacement = { one_over_sqrt_3 , -one_over_sqrt_3 , -one_over_sqrt_3 }; }
-				
-				if( pCell->position[0] > 0 && pCell->position[1] < 0 )
-				{ pCell->displacement = { -one_over_sqrt_3 , one_over_sqrt_3 , -one_over_sqrt_3 }; }
-				if( pCell->position[0] < 0 && pCell->position[1] < 0 )
-				{ pCell->displacement = { one_over_sqrt_3 , one_over_sqrt_3 , -one_over_sqrt_3 }; }
-			} 
-			else
-			{
-				if( pCell->position[0] > 0 && pCell->position[1] > 0 )
-				{ pCell->displacement = { -one_over_sqrt_3 , -one_over_sqrt_3 , one_over_sqrt_3 }; }
-				if( pCell->position[0] < 0 && pCell->position[1] > 0 )
-				{ pCell->displacement = { one_over_sqrt_3 , -one_over_sqrt_3 , one_over_sqrt_3 }; }
-				
-				if( pCell->position[0] > 0 && pCell->position[1] < 0 )
-				{ pCell->displacement = { -one_over_sqrt_3 , one_over_sqrt_3 , one_over_sqrt_3 }; }
-				if( pCell->position[0] < 0 && pCell->position[1] < 0 )
-				{ pCell->displacement = { one_over_sqrt_3 , one_over_sqrt_3 , one_over_sqrt_3 }; }				
-			}
-			return min_distance; 
-		}
-		
-		// planes - let's not worry for today 
-		
-	}
-	else
-	{
-		// check for 2D  exceptions 
-		
-		if( fabs( (pCell->position[0]) - (pCell->position[1]) ) < tolerance )
-		{
-			if( pCell->position[0] > 0 && pCell->position[1] > 0 )
-			{ pCell->displacement = { -one_over_sqrt_2 , -one_over_sqrt_2 , 0 }; }
-			if( pCell->position[0] < 0 && pCell->position[1] > 0 )
-			{ pCell->displacement = { one_over_sqrt_2 , -one_over_sqrt_2 , 0 }; }
-			
-			if( pCell->position[0] > 0 && pCell->position[1] < 0 )
-			{ pCell->displacement = { -one_over_sqrt_2 , one_over_sqrt_2 , 0 }; }
-			if( pCell->position[0] < 0 && pCell->position[1] < 0 )
-			{ pCell->displacement = { one_over_sqrt_2 , one_over_sqrt_2 , 0 }; }
-			return min_distance; 
-		}
 	}
 	
-	// no exceptions 
 	switch(nearest_boundary)
 	{
 		case 0:


### PR DESCRIPTION
- bottom line: at each mechanics time step, it will suffice to push the cell in a cardinal direction to increase the shortest distance to the boundary
- this is precisely what the current code currently does the vast majority of the time.
- now, it will do so for the previously defined edge cases
- in 2D sims, they looked for cells on line y=x
  - then used signs of x and y positions to determine which direction to push
  - no check for cells in upper left or lower right corners
  - the sign of the positions does not accurately convey which way to push (if all corners are negative, they would all push the same way)
- in 3D sims, they looked for cells on line x=y=z
  - similar issues but missing more cases (x=\pm y = \pm z)