### PR TITLE
handle an empty colormap element for substrate in svg

### DIFF
--- a/modules/PhysiCell_pathology.cpp
+++ b/modules/PhysiCell_pathology.cpp
@@ -789,6 +789,14 @@ void setup_svg_substrate_colormap(std::vector<std::string> &colormap)
 	std::string map_name = PhysiCell_settings.svg_substrate_colormap;
 	int name_length = map_name.size();
 	bool is_reversed = false;
+	if (name_length < 2)
+	{
+		std::cout << "WARNING: colormap name " << map_name << " is too short. Using default 'YlOrRd' colormap." << std::endl
+				  << "  Check your save//SVG//plot_substrate//colormap element in your configuration file." << std::endl;
+		map_name = "YlOrRd";
+		name_length = map_name.size();
+		PhysiCell_settings.svg_substrate_colormap = map_name;
+	}
 	if (map_name.substr(name_length-2,2)=="_r")
 	{
 		map_name = map_name.substr(0,name_length-2);


### PR DESCRIPTION
a user recently had this issue where the `<colormap>` element was empty but the substrate plotting was enabled. This throws a warning when the parsed colormap string is too short (empty or just a single character) and defaults to the `YlOrRd` colormap that is the default.

It's worth noting that defaulting to `YlOrRd` already occurs if the colormap string is not recognized. The issue with empty or 1-character colormaps is the check for a `_r` suffix required checking two characters from the end. So, in short, this makes sure these pathological colormap strings also fall back to the same default.