### PR TITLE
Fix use after free in cell attack 

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1207,6 +1207,9 @@ void delete_cell( int index )
 	// released internalized substrates (as of 1.5.x releases)
 	pDeleteMe->release_internalized_substrates(); 
 
+	// new Dec 2, 2025
+	pDeleteMe->remove_self_from_attackers(); 
+	
 	// performance goal: don't delete in the middle -- very expensive reallocation
 	// alternative: copy last element to index position, then shrink vector by 1 at the end O(constant)
 
@@ -3433,6 +3436,15 @@ void Cell::remove_all_spring_attachments( void )
 	return; 
 }
 
+void Cell::remove_self_from_attackers( void )
+{
+	for (Cell* pCell : phenotype.cell_interactions.attacked_by) 
+	{	
+		pCell->phenotype.cell_interactions.pAttackTarget = NULL;
+	}
+	phenotype.cell_interactions.attacked_by.clear();
+	return;
+}
 
 void attach_cells( Cell* pCell_1, Cell* pCell_2 )
 {

--- a/core/PhysiCell_cell.h
+++ b/core/PhysiCell_cell.h
@@ -238,6 +238,7 @@ class Cell : public Basic_Agent
 	void attach_cell_as_spring( Cell* pAddMe ); // done 
 	void detach_cell_as_spring( Cell* pRemoveMe ); // done 
 	void remove_all_spring_attachments( void ); // done 
+	void remove_self_from_attackers( void ); 
 
 	// I want to eventually deprecate this, by ensuring that 
 	// critical BioFVM and PhysiCell data elements are synced when they are needed 

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -1277,6 +1277,7 @@ Cell_Interactions::Cell_Interactions()
 	immunogenicities = {1}; 
 
 	pAttackTarget = NULL; 
+	attacked_by = std::vector<Cell*>{};
 	total_damage_delivered = 0.0; 
 
 	attack_duration = 30.0; // a typical attack duration for a T cell using perforin/granzyme is ~30 minutes

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -698,6 +698,7 @@ class Cell_Interactions
 	double attack_damage_rate;  
 
 	Cell* pAttackTarget; 
+	std::vector<Cell*> attacked_by;
 	double total_damage_delivered; 
 
 	double attack_duration; 

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -68,6 +68,7 @@
 #include "PhysiCell_standard_models.h" 
 #include "PhysiCell_cell.h" 
 #include "../modules/PhysiCell_pathology.h"
+#include <algorithm>
 
 namespace PhysiCell{
 	
@@ -1267,6 +1268,7 @@ void standard_cell_cell_interactions( Cell* pCell, Phenotype& phenotype, double 
 				if( UniformRandom() < probability ) 
 				{				
 					pCell->phenotype.cell_interactions.pAttackTarget = pTarget; 
+					pTarget->phenotype.cell_interactions.attacked_by.push_back(pCell);
 					attacked = true; 
 					/*					
 					std::cout << "*********   *********  ********  start atack **** " << PhysiCell_globals.current_time << std::endl; 
@@ -1345,6 +1347,14 @@ void standard_cell_cell_interactions( Cell* pCell, Phenotype& phenotype, double 
 				detach_cells_as_spring(pCell,pTarget); 
 
 				pCell->phenotype.cell_interactions.pAttackTarget = NULL; 
+				pTarget->phenotype.cell_interactions.attacked_by.erase( 
+					std::remove(
+						pTarget->phenotype.cell_interactions.attacked_by.begin(), 
+						pTarget->phenotype.cell_interactions.attacked_by.end(),
+						pCell), 
+					pTarget->phenotype.cell_interactions.attacked_by.end() 
+				);
+				
 			} 
 		} 
 


### PR DESCRIPTION
## Update

I updated this PR to only include cell attack, and updated the title accordingly. 
Initially, when deleting a cell, I would look for all cells to see if it was a target of another cell, and if so clean the pAttackTarget. 
I now modified the PR for cells to have a list of cells they are attacked by. That way, when deleting the cell, we know which cells we have to cleanup. 
I think that together with #409 and #410, we have a good fix for the issues that this PR was initially tackling. 

## initial PR


I had some crash that I wanted to fix for a while, and finally found the issues:

- pAttackTarget is not cleaned when the target is deleted, resulting in a use after free
- neighbors are not always symmetrical, but when we delete a cell we suppose they are, resulting in a use after free
- spring_attachments are not always symmetrical, but when we delete a cell we suppose they are, resulting in a use after free. 

Here the fixes I'm proposing for now: 
- When deleting a cell, I check that no other cell has it as an attack target and remove it if so
- When deleting a cell, after removing it from its known neighbors, check every cell to remove from unknown (non-symmetrical) neighbors
- When deleting a cell, after removing it from its known spring_attachments, check every cell to remove from unknown (non-symmetrical) spring_attachments

Clearly, this can be improved, but it fixes the present issues.