### PR TITLE
Resume simulation from checkpoint

### DIFF
--- a/modules/PhysiCell_MultiCellDS.cpp
+++ b/modules/PhysiCell_MultiCellDS.cpp
@@ -1294,4 +1294,947 @@ void write_spring_attached_cells_graph( std::string filename )
 
 	return; 
 }
+
+int resume_from_MultiCellDS(std::string folder_path, std::string xml_filename, bool create_cells, bool debug_print)
+{
+    pugi::xpath_node xpath_node;
+    pugi::xml_node node;
+
+    std::string xml_filepath = folder_path + "/" + xml_filename;
+    std::cout << xml_filepath << std::endl;
+    std::cout << __FUNCTION__ << "   xml_filepath= " << xml_filepath << std::endl;
+
+    pugi::xml_document doc; 
+    if (!doc.load_file(  xml_filepath.c_str()  ) )
+    {
+        std::cout << "Invalid file: " <<  xml_filepath << std::endl;
+        return -1;
+    }
+    // std::cout << "-- successfully read" << std::endl;
+
+    xpath_node = doc.select_node("//metadata//current_time");
+    node = xpath_node.node();
+    if (node)
+    {
+        std::cout << "\n   Success reading current_time\n" << std::endl;
+        PhysiCell_globals.current_time = xml_get_my_double_value(node);
+        std::cout << "--- resetting PhysiCell_globals.current_time " << PhysiCell_globals.current_time  << std::endl;
+    }
+    else
+    {
+        std::cout << " --- Error reading  metadata//current_time\n" << std::endl;
+        return -1;
+    }
+
+    pugi::xml_node microenv_data = doc.child("MultiCellDS").child("microenvironment").child("domain").child("data");
+    if (!microenv_data)
+    {
+        std::cout << "Error parsing microenv data: " << std::endl;
+        return -1;
+    }
+
+    xpath_node = doc.select_node("//microenvironment//domain//data[@type='matlab']");
+    node = xpath_node.node();
+    if (!node)
+    {
+        std::cout << "\n --- Error parsing microenv matlab data\n" << std::endl;
+        return -1;
+    }
+    std::string matlab_name = node.child_value("filename");
+    std::string microenv_mat_filename = folder_path + "/" + matlab_name;
+    // std::cout << "\n--- calling read_microenvironment_from_matlab" << std::endl;
+    bool read_microenv_flag = read_microenvironment_from_matlab( microenv_mat_filename );
+    if (read_microenv_flag )
+    {
+        std::cout << "\n   Success!\n" << std::endl;
+    }
+    else
+    {
+        std::cout << "   Error reading microenv matlab data " << std::endl;
+        return -1;
+    }
+
+    // Let's confirm the last cell param, before the custom data vars, is what we expect.
+    // If/when this labels list is modified, this code will need to be updated.
+
+    std::string label_path = "//cellular_information//cell_populations//custom//simplified_data//labels//label[@index=99]";
+    std::cout << "\nreading " << label_path << std::endl;
+    // xpath_node = doc.select_node(label_path);   // not allowed
+
+                // <label index="99" size="1" units="1/min">damage_repair_rate</label>
+                // <label index="100" size="1" units="dimensionless">sample</label>
+    // xpath_node = doc.select_node("//cellular_information//cell_populations//custom//simplified_data//labels//label[@index=99]");
+    // node = xpath_node.node();
+    // if (node)
+    // {
+    //     std::cout << "\n   Success!\n" << std::endl;
+    // }
+    // else
+    // {
+    //     std::cout << "\n --- Error reading node\n" << std::endl;
+    //     return -1;
+    // }
+    // std::string last_var = xml_get_my_string_value(node);
+    // std::cout << "last_var= " << last_var << std::endl;
+    // if (last_var != "damage_repair_rate")
+    // {
+    //     std::cout << "\n   Error: last var should be 'damage_repair_rate'\n" << std::endl;
+    //     return -1;
+    // }
+
+    xpath_node = doc.select_node("//cellular_information//cell_populations//custom//simplified_data//labels//label[@index=0]");
+    node = xpath_node.node();
+    if (!node)
+    {
+        std::cout << " --- Error: could not find <label index='0'\n" << std::endl;
+        return -1;
+    }
+
+    while (node)
+    {
+        std::string var_name = xml_get_my_string_value(node);
+        std::cout << " --- var_name=" << var_name << std::endl;
+        if (var_name == "damage_repair_rate")
+        {
+            break;
+        }
+        else
+        {
+            node = node.next_sibling();
+        }
+    }
+    std::string last_var = xml_get_my_string_value(node);
+    std::cout << "last_var= " << last_var << std::endl;
+    if (last_var != "damage_repair_rate")
+    {
+        std::cout << "\n   Error: last var should be 'damage_repair_rate'\n" << std::endl;
+        return -1;
+    }
+
+    // NOTE: even if a custom vector is defined before a custom scalar in the config file .xml,
+    //    they will be reordered in the "output000<#>.xml" to have all scalars followed by vectors
+            // <label index="99" size="1" units="1/min">damage_repair_rate</label>
+            // <label index="100" size="1" units="dimensionless">sample</label>
+            // <label index="101" size="1" units="">dummy</label>
+            // <label index="101" size="1" units="">dummy2</label>
+            // <label index="102" size="3" units="">myvec</label>
+
+    // store the name of the custom data [vector] variable and its size (# of values)
+    std::vector<std::pair<std::string, int>> custom_data_vars;
+    node = node.next_sibling(); // Move to the next sibling
+    while (node) {
+        std::string var = xml_get_my_string_value(node);
+        std::cout << "var: " << var << std::endl;  
+        if (node.attribute("index")) {
+            std::cout << "  index: " << node.attribute("index").value() << std::endl;  
+            int mysize = std::stoi(node.attribute("size").value());  
+            std::cout << "  size: " << mysize << std::endl;  
+            custom_data_vars.push_back({var, mysize});
+        }
+        node = node.next_sibling(); // Move to the next sibling
+    }
+    for (const auto& pair : custom_data_vars) 
+    {
+        std::cout << "name: " << pair.first << ", size: " << pair.second << std::endl;
+    }
+
+
+    std::cout << "\nreading //cellular_information//cell_populations//custom//simplified_data[@type='matlab']//filename" << std::endl;
+    xpath_node = doc.select_node("//cellular_information//cell_populations//custom//simplified_data[@type='matlab']//filename");
+    node = xpath_node.node();
+    if (node)
+    {
+        std::cout << "\n   Success!\n" << std::endl;
+    }
+    else
+    {
+        std::cout << "\n --- Error parsing cellular matlab data\n" << std::endl;
+        return -1;
+    }
+
+    matlab_name = xml_get_my_string_value(node);
+    std::cout << "\n ---> " << matlab_name << std::endl;
+    std::string cells_mat_filename = folder_path + "/" + matlab_name;
+    std::cout << " ---> " << cells_mat_filename << std::endl;
+
+    // pugi::xml_node microenv_data = doc.child("MultiCellDS").child("microenvironment").child("filename").child("data");
+
+    int retval = recreate_sim_state(cells_mat_filename, microenvironment, custom_data_vars, create_cells, debug_print);
+
+    return 0;
+}
+
+int recreate_sim_state(std::string filename, Microenvironment& M,   
+    std::vector<std::pair<std::string, int>> custom_data_vars, bool create_cells, bool debug_print)
+{
+    std::cout << "------- " << __FUNCTION__ << std::endl;
+
+    // Get number of substrates, cell types, death models
+    static int m_densities = microenvironment.number_of_densities();
+    static int n_cell_types = cell_definition_indices_by_name.size();
+    std::cout << "------- number_of_densities= " << m_densities << std::endl;
+    std::cout << "------- number of cell types= " << n_cell_types << std::endl;
+    static int nd = 0; // will be set from first cell
+    
+    // Open the MAT file for reading
+    FILE* fp = fopen(filename.c_str(), "rb");
+    if (fp == NULL)
+    {
+        std::cout << std::endl << "Error: Failed to open " << filename << " for reading." << std::endl << std::endl;
+        return -1;
+    }
+    
+    // Read MATLAB v4 header (5 integers)
+    int32_t header[5];
+    fread(header, sizeof(int32_t), 5, fp);
+    
+    int32_t type = header[0];        // Data type (should be 0 for double)
+    int32_t mrows = header[1];       // Number of rows
+    int32_t ncols = header[2];       // Number of columns
+    int32_t imagf = header[3];       // Imaginary flag (should be 0)
+    int32_t namelen = header[4];     // Length of name + 1
+    
+    // Read variable name
+    char* var_name = new char[namelen];
+    fread(var_name, sizeof(char), namelen, fp);
+    
+    int size_of_each_datum = mrows;
+    int number_of_data_entries = ncols;
+    
+    std::cout << "Reading " << number_of_data_entries << " cells with " 
+              << size_of_each_datum << " data points each..." << std::endl;
+    
+    delete[] var_name;
+    
+    double dTemp;
+    double position[3];
+    int cell_ID, cell_type;
+    double cell_vol;
+    double orientation[3];
+    double velocity[3];
+    double migration_bias_direction[3];
+    double motility_vector[3];
+    double params[10];
+    double *dptr;
+    
+    // Store attack target IDs for later resolution
+    std::vector<int> attack_target_ids;
+    
+    Cell_Definition* pCD; 
+    Cell* pCell;
+    std::vector<std::pair<Cell*, int>> cell_attackID;
+
+    // Read each cell
+    std::cout << "reading cell data..." << std::endl;
+    for (int i = 0; i < number_of_data_entries; i++)
+    {
+        if (debug_print)
+        { std::cout << "\n ------  reading cell # " << i << std::endl; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        cell_ID = (int)dTemp;
+        if (debug_print)
+        { std::cout << "ID= " << cell_ID << std::endl; }
+        
+        fread(position, sizeof(double), 3, fp);
+        if (debug_print)
+        { std::cout << "pos= " << position[0]<<", "<< position[1] << ", " << position[2] << std::endl; }
+        
+        fread(&cell_vol, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "total vol= " << cell_vol  << std::endl; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        cell_type = (int)dTemp;
+        if (debug_print)
+        { std::cout << "type= " << cell_type  << std::endl; }
+
+        if (create_cells)
+        {
+            // Cell_Definition* pCD = cell_definitions_by_type[cell_type]; 
+            pCD = cell_definitions_by_type[cell_type];    // rwh: better?
+            pCell = create_cell( *pCD );
+
+            pCell->ID = cell_ID;
+            pCell->type = cell_type;
+            pCell->phenotype.volume.total = cell_vol;
+
+            pCell->assign_position(position[0], position[1], position[2]);
+            pCell->update_voxel_index();
+        }
+        
+        // -------- cycle and phase params
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.cycle.model().code= " << int(dTemp)  << std::endl; }
+
+        if (create_cells)
+        { pCell->phenotype.cycle.model().code = int(dTemp); }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        // std::cout << "phenotype.cycle.current_phase()= " << int(dTemp)  << std::endl;
+        int current_phase_code = int(dTemp);   // used below
+        if (debug_print)
+        {
+            std::cout << "current_phase_code = " << current_phase_code << std::endl;
+            std::cout << "phenotype.cycle.current_phase().code = " << int(dTemp)  << std::endl;
+        }
+        if (create_cells)
+        { pCell->phenotype.cycle.current_phase().code = int(dTemp); }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.cycle.data.elapsed_time_in_phase= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cycle.data.elapsed_time_in_phase = dTemp; }
+        
+
+        // -------- volume params
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.volume.nuclear= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.volume.nuclear = dTemp; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.volume.cytoplasmic= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.volume.cytoplasmic = dTemp; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.volume.fluid_fraction= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.volume.fluid_fraction = dTemp; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.volume.calcified_fraction= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.volume.calcified_fraction = dTemp; }
+        
+
+        // -------- state 
+        fread(orientation, sizeof(double), 3, fp);
+        if (debug_print)
+        { std::cout << "orientation= " << orientation[0]<<", "<<orientation[1]<<", " << orientation[2]  << std::endl; }
+        if (create_cells)
+        {
+            pCell->state.orientation[0] = orientation[0];
+            pCell->state.orientation[1] = orientation[1];
+            pCell->state.orientation[2] = orientation[2];
+        }
+        
+        // -------- geometry 
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.geometry.polarity= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.geometry.polarity = dTemp; }
+        
+
+        fread(velocity, sizeof(double), 3, fp);
+        if (debug_print)
+        { std::cout << "velocity= " << velocity[0]<<", "<<velocity[1]<<", " << velocity[2]  << std::endl; }
+        if (create_cells)
+        {
+            pCell->velocity[0] = velocity[0];
+            pCell->velocity[1] = velocity[1];
+            pCell->velocity[2] = velocity[2];
+        }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "state.simple_pressure= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->state.simple_pressure = dTemp; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "state.number_of_nuclei= " << (int)dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->state.number_of_nuclei = (int)dTemp; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "state.total_attack_time= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->state.total_attack_time = dTemp; }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "state.contact_with_basement_membrane= " << bool(dTemp)  << std::endl; }
+        if (create_cells)
+        { pCell->state.contact_with_basement_membrane = (bool)dTemp; }
+        
+
+
+        // cell cycle
+        // e.g., phenotype.cycle.model().find_phase_index( PhysiCell_constants::quiescent )
+        int phase_index = pCell->phenotype.cycle.model().find_phase_index(current_phase_code);
+        if (debug_print)
+        {
+            std::cout << "------ cycle:\n";
+            std::cout << "  --- phase_index =" << phase_index  << std::endl;
+        }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.cycle.data.exit_rate(phase_index)= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cycle.data.exit_rate(phase_index) = dTemp; }
+        
+        // elapsed_time_in_phase (duplicate: rf. https://github.com/MathCancer/PhysiCell/pull/380)
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "phenotype.cycle.data.elapsed_time_in_phase= " << dTemp  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cycle.data.elapsed_time_in_phase = dTemp; }
+        
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        {
+            std::cout << "------ death:\n";
+            std::cout << " phenotype.death.dead= " << int(dTemp)  << std::endl;
+        }
+        if (create_cells)
+        { pCell->phenotype.death.dead = (int)dTemp; } // read bool as int
+        
+        if (debug_print)
+        { std::cout << "------reading phenotype.death.current_death_model_index :\n"; }
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << " phenotype.death.current_death_model_index= " << int(dTemp)  << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.death.current_death_model_index = (int)dTemp; }
+        // std::cout << " -- past current_death_model_index " << std::endl;
+        
+        int ndeath = 2;  // 2 types of death
+        if (create_cells)
+        {
+            pCell->phenotype.death.rates.resize(2);  
+            if (debug_print)
+            { std::cout << " phenotype.death.rates.size()= " <<  pCell->phenotype.death.rates.size()  << std::endl; }
+        }
+        // std::cout << " ndeath= " <<  ndeath  << std::endl;
+        for (int idx=0; idx < ndeath; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << "  phenotype.death.rates[" << idx << "] = " << dTemp  << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.death.rates[idx] = dTemp; }
+        }
+        
+
+        // Volume rates
+        fread(params, sizeof(double), 7, fp);
+        if (debug_print)
+        {
+            std::cout << "------ volume:\n";
+            std::cout << "phenotype.volume.cytoplasmic_biomass_change_rate= " << params[0] << std::endl;
+            std::cout << "phenotype.volume.nuclear_biomass_change_rate= " << params[1] << std::endl;
+            std::cout << "phenotype.volume.fluid_change_rate= " << params[2] << std::endl;
+            std::cout << "phenotype.volume.calcification_rate= " << params[3] << std::endl;
+            std::cout << "phenotype.volume.target_solid_cytoplasmic= " << params[4] << std::endl;
+            std::cout << "phenotype.volume.target_solid_nuclear= " << params[5] << std::endl;
+            std::cout << "phenotype.volume.target_fluid_fraction= " << params[6] << std::endl;
+        }
+        if (create_cells)
+        {
+            pCell->phenotype.volume.cytoplasmic_biomass_change_rate = params[0];
+            pCell->phenotype.volume.nuclear_biomass_change_rate = params[1];
+            pCell->phenotype.volume.fluid_change_rate = params[2];
+            pCell->phenotype.volume.calcification_rate = params[3];
+            pCell->phenotype.volume.target_solid_cytoplasmic = params[4];
+            pCell->phenotype.volume.target_solid_nuclear = params[5];
+            pCell->phenotype.volume.target_fluid_fraction = params[6];
+        }
+
+        
+        // Geometry
+        fread(params, sizeof(double), 3, fp);
+        if (debug_print)
+        {
+            std::cout << "------ geometry:\n";
+            std::cout << "phenotype.geometry.radius= " << params[0] << std::endl;
+            std::cout << "phenotype.geometry.nuclear_radius= " << params[1] << std::endl;
+            std::cout << "phenotype.geometry.surface_area= " << params[2] << std::endl;
+        }
+        if (create_cells)
+        {
+            pCell->phenotype.geometry.radius= params[0];
+            pCell->phenotype.geometry.nuclear_radius= params[1];
+            pCell->phenotype.geometry.surface_area = params[2];
+        }
+        
+        // Mechanics
+        fread(params, sizeof(double), 4, fp);
+        if (debug_print)
+        {
+            std::cout << "------ mechanics:\n";
+            std::cout << "phenotype.mechanics.cell_cell_adhesion_strength= " << params[0] << std::endl;
+            std::cout << "phenotype.mechanics.cell_BM_adhesion_strength= " << params[1] << std::endl;
+            std::cout << "phenotype.mechanics.cell_cell_repulsion_strength= " << params[2] << std::endl;
+            std::cout << "phenotype.mechanics.cell_BM_repulsion_strength= " << params[3] << std::endl;
+        }
+        if (create_cells)
+        {
+            pCell->phenotype.mechanics.cell_cell_adhesion_strength= params[0];
+            pCell->phenotype.mechanics.cell_BM_adhesion_strength= params[1];
+            pCell->phenotype.mechanics.cell_cell_repulsion_strength = params[2];
+            pCell->phenotype.mechanics.cell_BM_repulsion_strength = params[3];
+        }
+
+        // fread(pCell->phenotype.mechanics.cell_adhesion_affinities.data(), sizeof(double), n, fp);  // NOTE
+        if (create_cells)
+        { pCell->phenotype.mechanics.cell_adhesion_affinities.resize(n_cell_types); }
+        for (int idx=0; idx < n_cell_types; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.mechanics.cell_adhesion_affinities[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.mechanics.cell_adhesion_affinities[idx] = dTemp; }
+        }
+
+        // continuation of mechanics params
+        fread(params, sizeof(double), 5, fp);
+        if (debug_print)
+        {
+            std::cout << "pCell->phenotype.mechanics.attachment_elastic_constant = " << params[0] << std::endl;
+            std::cout << "pCell->phenotype.mechanics.attachment_rate = " << params[1] << std::endl;
+            std::cout << "pCell->phenotype.mechanics.detachment_rate = " << params[2] << std::endl;
+            std::cout << "pCell->phenotype.relative_maximum_adhesion_distance = " << params[3] << std::endl;
+            std::cout << "pCell->phenotype.mechanics.maximum_number_of_attachments = " << (int)params[4] << std::endl;
+        }
+        if (create_cells)
+        {
+            pCell->phenotype.mechanics.attachment_elastic_constant = params[0];
+            pCell->phenotype.mechanics.attachment_rate = params[1];
+            pCell->phenotype.mechanics.detachment_rate = params[2];
+            pCell->phenotype.mechanics.relative_maximum_adhesion_distance = params[3];
+            pCell->phenotype.mechanics.maximum_number_of_attachments = (int)params[4];
+        }
+
+        
+        // Motility
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        {
+            std::cout << "------ motility:\n";
+            std::cout << "pCell->phenotype.motility.is_motile = " << (bool)dTemp << std::endl;
+        }
+        if (create_cells)
+        { pCell->phenotype.motility.is_motile = (bool)dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.motility.persistence_time = " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.motility.persistence_time = dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.motility.migration_speed = " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.motility.migration_speed = dTemp; }
+
+        fread(migration_bias_direction, sizeof(double), 3, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.motility.migration_speed = " << migration_bias_direction[0]<<", " <<migration_bias_direction[1] << ", " << migration_bias_direction[2] << std::endl; }
+        if (create_cells)
+        {
+            pCell->phenotype.motility.migration_bias_direction[0] = migration_bias_direction[0];
+            pCell->phenotype.motility.migration_bias_direction[1] = migration_bias_direction[1];
+            pCell->phenotype.motility.migration_bias_direction[2] = migration_bias_direction[2];
+        }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.motility.migration_bias = " << dTemp <<std::endl; }
+        if (create_cells)
+        { pCell->phenotype.motility.migration_bias = dTemp; }
+
+        fread(motility_vector, sizeof(double), 3, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.motility.motility_vector = " << motility_vector[0]<<", " <<motility_vector[1] << ", " << motility_vector[2] << std::endl; }
+        if (create_cells)
+        {
+            pCell->phenotype.motility.motility_vector[0] = motility_vector[0];
+            pCell->phenotype.motility.motility_vector[1] = motility_vector[1];
+            pCell->phenotype.motility.motility_vector[2] = motility_vector[2];
+        }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.motility.chemotaxis_index = " << (int)dTemp <<std::endl; }
+        if (create_cells)
+        { pCell->phenotype.motility.chemotaxis_index = (int)dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.motility.chemotaxis_direction = " << (int)dTemp <<std::endl; }
+        if (create_cells)
+        { pCell->phenotype.motility.chemotaxis_direction = (int)dTemp; }
+
+        // rwh - is this correct?
+        if (create_cells)
+        { pCell->phenotype.motility.chemotactic_sensitivities.resize(m_densities); }
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.motility.chemotactic_sensitivities[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.motility.chemotactic_sensitivities[idx] = dTemp; }
+        }
+        
+        // Secretion
+        if (debug_print)
+        { std::cout << "------ motility:\n"; }
+            
+        // fread(pCell->phenotype.secretion.secretion_rates.data(), sizeof(double), m, fp);
+        if (create_cells)
+        { pCell->phenotype.secretion.secretion_rates.resize(m_densities); }
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.secretion.secretion_rates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.secretion.secretion_rates[idx] = dTemp; }
+        }
+
+        // fread(pCell->phenotype.secretion.uptake_rates.data(), sizeof(double), m, fp);
+        if (create_cells)
+        { pCell->phenotype.secretion.uptake_rates.resize(m_densities); }
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.secretion.uptake_rates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.secretion.uptake_rates[idx] = dTemp; }
+        }
+
+        // fread(pCell->phenotype.secretion.saturation_densities.data(), sizeof(double), m, fp);
+        if (create_cells)
+        { pCell->phenotype.secretion.saturation_densities.resize(m_densities); }
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.secretion.saturation_densities[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.secretion.saturation_densities[idx] = dTemp; }
+        }
+
+        // fread(pCell->phenotype.secretion.net_export_rates.data(), sizeof(double), m, fp);
+        if (create_cells)
+        { pCell->phenotype.secretion.net_export_rates.resize(m_densities); }
+
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.secretion.net_export_rates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.secretion.net_export_rates[idx] = dTemp; }
+        }
+        
+
+        // Molecular
+        if (debug_print)
+        { std::cout << "------ molecular:\n"; }
+        if (create_cells)
+        { pCell->phenotype.molecular.internalized_total_substrates.resize(m_densities); }
+
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.molecular.internalized_total_substrates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.molecular.internalized_total_substrates[idx] = dTemp; }
+        }
+
+        // fread(pCell->phenotype.molecular.fraction_released_at_death.data(), sizeof(double), m, fp);
+        if (create_cells)
+        { pCell->phenotype.molecular.fraction_released_at_death.resize(m_densities); }
+
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.molecular.fraction_released_at_death[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.molecular.fraction_released_at_death[idx] = dTemp; }
+        }
+
+        // fread(pCell->phenotype.molecular.fraction_transferred_when_ingested.data(), sizeof(double), m, fp);
+        if (create_cells)
+        { pCell->phenotype.molecular.fraction_transferred_when_ingested.resize(m_densities); }
+        for (int idx=0; idx < m_densities; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.molecular.fraction_transferred_when_ingested[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.molecular.fraction_transferred_when_ingested[idx] = dTemp; }
+        }
+        
+
+        // Interactions
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        {
+            std::cout << "------ interactions:\n";
+            std::cout << "pCell->phenotype.cell_interactions.apoptotic_phagocytosis_rate = " << dTemp <<std::endl;
+        }
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.apoptotic_phagocytosis_rate = dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_interactions.necrotic_phagocytosis_rate = " << dTemp <<std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.necrotic_phagocytosis_rate = dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_interactions.other_dead_phagocytosis_rate = " << dTemp <<std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.other_dead_phagocytosis_rate = dTemp; }
+
+        // fread(pCell->phenotype.cell_interactions.live_phagocytosis_rates.data(), sizeof(double), n, fp);
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.live_phagocytosis_rates.resize(n_cell_types); }
+        for (int idx=0; idx < n_cell_types; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.cell_interactions.live_phagocytosis_rates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.cell_interactions.live_phagocytosis_rates[idx] = dTemp; }
+        }
+
+        // fread(pCell->phenotype.cell_interactions.attack_rates.data(), sizeof(double), n, fp);
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.attack_rates.resize(n_cell_types); }
+        for (int idx=0; idx < n_cell_types; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.cell_interactions.attack_rates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.cell_interactions.attack_rates[idx] = dTemp; }
+        }
+
+        // fread(pCell->phenotype.cell_interactions.immunogenicities.data(), sizeof(double), n, fp);
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.immunogenicities.resize(n_cell_types); }
+        for (int idx=0; idx < n_cell_types; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.cell_interactions.immunogenicities[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.cell_interactions.immunogenicities[idx] = dTemp; }
+        }
+        
+        // // name = "attack_target"; 
+		// Cell* pTarget = pCell->phenotype.cell_interactions.pAttackTarget; 
+		// int AttackID = -1; 
+		// if( pTarget )
+		// { AttackID = pTarget->ID; }
+		// dTemp = (double) AttackID; 
+		// std::fwrite( &(dTemp) , sizeof(double) , 1 , fp ); 
+ 		// // name = "attack_damage_rate"; 
+		// std::fwrite( &( pCell->phenotype.cell_interactions.attack_damage_rate ) , sizeof(double) , 1 , fp ); 
+ 		// // name = "attack_duration"; 
+		// std::fwrite( &( pCell->phenotype.cell_interactions.attack_duration ) , sizeof(double) , 1 , fp ); 
+ 		// // name = "total_damage_delivered"; 
+		// std::fwrite( &( pCell->phenotype.cell_interactions.total_damage_delivered ) , sizeof(double) , 1 , fp ); 
+
+        // attack_target (stored as ID, need to resolve later as the actual cell pointer)
+        fread(&dTemp, sizeof(double), 1, fp);
+        int attack_target_ID = (int)dTemp;
+        if (debug_print)
+        { std::cout << "------- pCell->phenotype.cell_interactions.pAttackTarget (attack_target ID)= " << attack_target_ID << std::endl; }
+        if (create_cells)
+        {
+            if (attack_target_ID < 0)
+            {
+                pCell->phenotype.cell_interactions.pAttackTarget = NULL;
+            }
+            else
+            {
+                // keep track of this cell and the target cell's ID; resolve later
+                cell_attackID.push_back({pCell, attack_target_ID});
+            }
+        }
+        
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_interactions.attack_damage_rate = " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.attack_damage_rate = dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_interactions.attack_duration = " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.attack_duration = dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_interactions.total_damage_delivered = " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.total_damage_delivered = dTemp; }
+
+
+        // fread(pCell->phenotype.cell_interactions.fusion_rates.data(), sizeof(double), n, fp);
+        
+        // Transformations
+        // fread(pCell->phenotype.cell_transformations.transformation_rates.data(), sizeof(double), n, fp);
+        
+        // Asymmetric division
+        // fread(pCell->phenotype.cycle.asymmetric_division.asymmetric_division_probabilities.data(), sizeof(double), n, fp);
+
+        if (create_cells)
+        { pCell->phenotype.cell_interactions.fusion_rates.resize(n_cell_types); }
+        for (int idx=0; idx < n_cell_types; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.cell_interactions.fusion_rates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.cell_interactions.fusion_rates[idx] = dTemp; }
+        }
+
+        if (create_cells)
+        { pCell->phenotype.cell_transformations.transformation_rates.resize(n_cell_types); }
+        for (int idx=0; idx < n_cell_types; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.cell_transformations.transformation_rates[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.cell_transformations.transformation_rates[idx] = dTemp; }
+        }
+
+        if (create_cells)
+        { pCell->phenotype.cycle.asymmetric_division.asymmetric_division_probabilities.resize(n_cell_types); }
+        for (int idx=0; idx < n_cell_types; idx++)
+        {
+            fread(&dTemp, sizeof(double), 1, fp);
+            if (debug_print)
+            { std::cout << " phenotype.cycle.asymmetric_division.asymmetric_division_probabilities[" << idx << "] = " << dTemp << std::endl; }
+            if (create_cells)
+            { pCell->phenotype.cycle.asymmetric_division.asymmetric_division_probabilities[idx] = dTemp; }
+        }
+        
+        // Cell integrity
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_integrity.damage= " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_integrity.damage = dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_integrity.damage_rate= " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_integrity.damage_rate = dTemp; }
+
+        fread(&dTemp, sizeof(double), 1, fp);
+        if (debug_print)
+        { std::cout << "pCell->phenotype.cell_integrity.damage_repair_rate= " << dTemp << std::endl; }
+        if (create_cells)
+        { pCell->phenotype.cell_integrity.damage_repair_rate = dTemp; }
+        
+
+        if (debug_print)
+        { std::cout << "   ----  reading custom data  ----" << std::endl; }
+        for (const auto& pair : custom_data_vars) 
+        {
+            if (pair.second == 1)   // got a custom (scalar) variable
+            {
+                fread(&dTemp, sizeof(double), 1, fp);
+                if (debug_print)
+                { std::cout << "custom var: " << pair.first << " = " << dTemp << std::endl; }
+
+                // find the variable 
+                // int n = pCD->custom_data.find_variable_index( name ); 
+                int idx_var = pCell->custom_data.find_variable_index( pair.first ); 
+                // if it exists, overwrite 
+                if( idx_var > -1 )
+                { 
+                    pCell->custom_data.variables[idx_var].value = pair.second; 
+                }
+                else
+                {
+                    std::cout << __FUNCTION__ << "   Error: got an invalid custom data var name: " << pair.first << " . Exiting! " << std::endl;
+                    std::exit(-1);
+                }
+            }
+
+            else   // got a custom vector variable
+            {
+                for (int jj=0; jj<pair.second; jj++)   // loop over all elms of the vector
+                {
+                    // std::cout << "pair.first << ", size: " << pair.second << std::endl;
+                    fread(&dTemp, sizeof(double), 1, fp);
+                    if (debug_print)
+                    { std::cout << "custom vector var: " << pair.first << "[" << jj << "] = " << dTemp << std::endl; }
+
+                    // find the variable 
+                    // int n = pCD->custom_data.find_variable_index( name ); 
+                    int idx_var = pCell->custom_data.find_vector_variable_index( pair.first ); 
+                    // if it exists, overwrite 
+                    if( idx_var > -1 )
+                    { 
+                        pCell->custom_data.vector_variables[idx_var].value[jj] = pair.second;
+                    }
+                    else
+                    {
+                        std::cout << __FUNCTION__ << "   Error: got an invalid custom data vector name: " << pair.first << " . Exiting! " << std::endl;
+                        std::exit(-1);
+                    }
+                }
+            }
+        }
+    }
+    
+    if (create_cells)
+    {
+        if (debug_print)
+        { std::cout << "----  resolve cell_interactions.pAttackTarget (if any) ----" << std::endl; }
+        // recall:  cell_attackID.push_back({pCell, attack_target_ID});
+        for (const auto& pair : cell_attackID)  // for each pair, find cell with ID
+        {
+            for (auto* cell : *all_cells)   // loop over all cells
+            {
+                if (cell->ID == pair.second)
+                {
+                    (pair.first)->phenotype.cell_interactions.pAttackTarget = cell;
+                    if (debug_print)
+                    { std::cout << "    cell ID=" << (pair.first)->ID << " attacking  cell ID=" << cell->ID << std::endl; }
+                    break;
+                }
+            }
+        }
+
+        std::cout << __FUNCTION__ << "--- (*all_cells).size() = " << (*all_cells).size() << std::endl;
+    }
+
+    fclose(fp);
+    
+    std::cout << __FUNCTION__ << ": read " << number_of_data_entries << " cells from " << filename << std::endl;
+
+    return 0;
+}
 };

--- a/modules/PhysiCell_MultiCellDS.h
+++ b/modules/PhysiCell_MultiCellDS.h
@@ -106,6 +106,9 @@ void write_neighbor_graph( std::string filename );
 void write_attached_cells_graph( std::string filename ); 
 void write_spring_attached_cells_graph( std::string filename ); 
 
+int resume_from_MultiCellDS(std::string folder_path, std::string xml_filename, bool create_cells = true, bool debug_print = false);
+int recreate_sim_state(std::string filename, Microenvironment& M, std::vector<std::pair<std::string, int>> custom_data_vars, bool create_cells, bool debug_print);
+
 };
 
 #endif

--- a/unit_tests/resume_sim/config/cycle_phase_3cells_custom_vecs.xml
+++ b/unit_tests/resume_sim/config/cycle_phase_3cells_custom_vecs.xml
@@ -1,0 +1,546 @@
+<PhysiCell_settings version="devel-version">
+
+    <cell_rules>
+        <rulesets>
+            <ruleset protocol="CBHG" version="3.0" format="csv" enabled="true">
+                <folder>config</folder>
+                <filename>cell_cycle_rules.csv</filename>
+            </ruleset>
+        </rulesets>
+    </cell_rules>
+
+    <domain>
+        <x_min>-200.0</x_min>
+        <x_max>200.0</x_max>
+        <y_min>-200.0</y_min>
+        <y_max>200.0</y_max>
+        <z_min>-10.0</z_min>
+        <z_max>10.0</z_max>
+        <dx>20.0</dx>
+        <dy>20.0</dy>
+        <dz>20.0</dz>
+        <use_2D>true</use_2D>
+    </domain>
+
+    <overall>
+        <max_time units="min">2880.0</max_time>
+        <time_units>min</time_units>
+        <space_units>micron</space_units>
+        <dt_diffusion units="min">0.01</dt_diffusion>
+        <dt_mechanics units="min">0.1</dt_mechanics>
+        <dt_phenotype units="min">6</dt_phenotype>
+    </overall>
+
+    <parallel>
+        <omp_num_threads>1</omp_num_threads>
+    </parallel>
+
+    <save>
+        <folder>output</folder>
+        <full_data>
+            <interval units="min">30</interval>
+            <enable>true</enable>
+        </full_data>
+        <SVG>
+            <interval units="min">30</interval>
+            <enable>true</enable>
+            <plot_substrate enabled="false" limits="false">
+                <substrate>signal</substrate>
+                <min_conc>0</min_conc>
+                <max_conc>38</max_conc>
+                <colormap>viridis_r</colormap>
+            </plot_substrate>
+        </SVG>
+        <legacy_data>
+            <enable>false</enable>
+        </legacy_data>
+    </save>
+
+    <options>
+        <legacy_random_points_on_sphere_in_divide>false</legacy_random_points_on_sphere_in_divide>
+        <virtual_wall_at_domain_edge>true</virtual_wall_at_domain_edge>
+        <random_seed>0</random_seed>
+    </options>
+
+    <microenvironment_setup>
+        <variable name="signal" units="dimensionless" ID="0">
+            <physical_parameter_set>
+                <diffusion_coefficient units="micron^2/min">20</diffusion_coefficient>
+                <decay_rate units="1/min">0</decay_rate>
+            </physical_parameter_set>
+            <initial_condition units="mmHg" />
+            <Dirichlet_boundary_condition units="mmHg" enabled="True">38</Dirichlet_boundary_condition>
+            <Dirichlet_options>
+                <boundary_value ID="xmin" enabled="True">38</boundary_value>
+                <boundary_value ID="xmax" enabled="False">38</boundary_value>
+                <boundary_value ID="ymin" enabled="False">38</boundary_value>
+                <boundary_value ID="ymax" enabled="False">38</boundary_value>
+                <boundary_value ID="zmin" enabled="True">38</boundary_value>
+                <boundary_value ID="zmax" enabled="True">38</boundary_value>
+            </Dirichlet_options>
+        </variable>
+        <options>
+            <calculate_gradients>true</calculate_gradients>
+            <track_internalized_substrates_in_each_agent>false</track_internalized_substrates_in_each_agent>
+            <initial_condition type="matlab" enabled="false">
+                <filename>./config/initial.mat</filename>
+            </initial_condition>
+            <dirichlet_nodes type="matlab" enabled="false">
+                <filename>./config/dirichlet.mat</filename>
+            </dirichlet_nodes>
+        </options>
+    </microenvironment_setup>
+
+    <cell_definitions>
+        <cell_definition name="ctype1" ID="0">
+            <phenotype>
+                <cycle code="5" name="live">
+                    <phase_durations units="min">
+                        <duration index="0" fixed_duration="true">1440</duration>
+                    </phase_durations>
+                    <standard_asymmetric_division enabled="False">
+                        <asymmetric_division_probability name="ctype1" units="dimensionless">1.0</asymmetric_division_probability>
+                        <asymmetric_division_probability name="ctype2" units="dimensionless">0</asymmetric_division_probability>
+                        <asymmetric_division_probability name="ctype3" units="dimensionless">0</asymmetric_division_probability>
+                    </standard_asymmetric_division>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_transition_rates units="1/min">
+                            <rate start_index="0" end_index="1" fixed_duration="false">0.001938</rate>
+                        </phase_transition_rates>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_transition_rates units="1/min">
+                            <rate start_index="0" end_index="1" fixed_duration="false">9000000000.0</rate>
+                            <rate start_index="1" end_index="2" fixed_duration="true">1.15741e-05</rate>
+                        </phase_transition_rates>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-02</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-05</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-4</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">7e-05</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0.0</calcified_fraction>
+                    <calcification_rate units="1/min">0.0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="ctype1">1</cell_adhesion_affinity>
+                        <cell_adhesion_affinity name="ctype2">1.0</cell_adhesion_affinity>
+                        <cell_adhesion_affinity name="ctype3">1.0</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">0.0</speed>
+                    <persistence_time units="min">0</persistence_time>
+                    <migration_bias units="dimensionless">0.0</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>true</enabled>
+                            <substrate>signal</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="signal">0.0</chemotactic_sensitivity>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="signal">
+                        <secretion_rate units="1/min">0.0</secretion_rate>
+                        <secretion_target units="substrate density">1.0</secretion_target>
+                        <uptake_rate units="1/min">0.0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0.0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="ctype1" units="1/min">0.0</phagocytosis_rate>
+                        <phagocytosis_rate name="ctype2" units="1/min">0.0</phagocytosis_rate>
+                        <phagocytosis_rate name="ctype3" units="1/min">0.0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="ctype1" units="1/min">0.0</attack_rate>
+                        <attack_rate name="ctype2" units="1/min">0.0</attack_rate>
+                        <attack_rate name="ctype3" units="1/min">0.0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1.0</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="ctype1" units="1/min">0.0</fusion_rate>
+                        <fusion_rate name="ctype2" units="1/min">0.0</fusion_rate>
+                        <fusion_rate name="ctype3" units="1/min">0.0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="ctype1" units="1/min">0.0</transformation_rate>
+                        <transformation_rate name="ctype2" units="1/min">0.0</transformation_rate>
+                        <transformation_rate name="ctype3" units="1/min">0.0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="true" units="dimensionless" description="">100</sample>
+                <dummy conserved="false" units="" description="">0.0</dummy>
+                <myvec conserved="false" units="" description="">1.0 2.0 3.0</myvec>
+                <dummy2 conserved="false" units="" description="">42.0</dummy2>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+          </initial_parameter_distributions>
+        </cell_definition>
+        <cell_definition name="ctype2" ID="1">
+            <phenotype>
+                <cycle code="1" name="basic Ki67">
+                    <phase_durations units="min">
+                        <duration index="0" fixed_duration="true">360</duration>
+                        <duration index="1" fixed_duration="true">720</duration>
+                    </phase_durations>
+                    <standard_asymmetric_division enabled="False">
+                        <asymmetric_division_probability name="ctype1" units="dimensionless">0</asymmetric_division_probability>
+                        <asymmetric_division_probability name="ctype2" units="dimensionless">1.0</asymmetric_division_probability>
+                        <asymmetric_division_probability name="ctype3" units="dimensionless">0</asymmetric_division_probability>
+                    </standard_asymmetric_division>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_transition_rates units="1/min">
+                            <rate start_index="0" end_index="1" fixed_duration="false">0.001938</rate>
+                        </phase_transition_rates>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_transition_rates units="1/min">
+                            <rate start_index="0" end_index="1" fixed_duration="false">9000000000.0</rate>
+                            <rate start_index="1" end_index="2" fixed_duration="true">1.15741e-05</rate>
+                        </phase_transition_rates>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-02</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-05</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-4</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">7e-05</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0.0</calcified_fraction>
+                    <calcification_rate units="1/min">0.0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="ctype1">1.0</cell_adhesion_affinity>
+                        <cell_adhesion_affinity name="ctype2">1.0</cell_adhesion_affinity>
+                        <cell_adhesion_affinity name="ctype3">1.0</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1.0</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.7</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>true</enabled>
+                            <substrate>signal</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="signal">0.0</chemotactic_sensitivity>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="signal">
+                        <secretion_rate units="1/min">0.0</secretion_rate>
+                        <secretion_target units="substrate density">1.0</secretion_target>
+                        <uptake_rate units="1/min">0.0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0.0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="ctype1" units="1/min">0.0</phagocytosis_rate>
+                        <phagocytosis_rate name="ctype2" units="1/min">0.0</phagocytosis_rate>
+                        <phagocytosis_rate name="ctype3" units="1/min">0.0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="ctype1" units="1/min">0.0</attack_rate>
+                        <attack_rate name="ctype2" units="1/min">0.0</attack_rate>
+                        <attack_rate name="ctype3" units="1/min">0.0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1.0</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="ctype1" units="1/min">0.0</fusion_rate>
+                        <fusion_rate name="ctype2" units="1/min">0.0</fusion_rate>
+                        <fusion_rate name="ctype3" units="1/min">0.0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="ctype1" units="1/min">0.0</transformation_rate>
+                        <transformation_rate name="ctype2" units="1/min">0.0</transformation_rate>
+                        <transformation_rate name="ctype3" units="1/min">0.0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="true" units="dimensionless" description="">200</sample>
+                <dummy conserved="false" units="" description="">0.0</dummy>
+                <myvec conserved="false" units="" description="">2.0 3.0 4.0</myvec>
+                <dummy2 conserved="false" units="" description="">43.0</dummy2>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+          </initial_parameter_distributions>
+        </cell_definition>
+        <cell_definition name="ctype3" ID="2">
+            <phenotype>
+                <cycle code="6" name="Flow cytometry model (separated)">
+                    <phase_durations units="min">
+                        <duration index="0" fixed_duration="true">298.50746</duration>
+                        <duration index="1" fixed_duration="true">480.76923</duration>
+                        <duration index="2" fixed_duration="true">239.80815</duration>
+                        <duration index="3" fixed_duration="true">59.88024</duration>
+                    </phase_durations>
+                    <standard_asymmetric_division enabled="False">
+                        <asymmetric_division_probability name="ctype1" units="dimensionless">0</asymmetric_division_probability>
+                        <asymmetric_division_probability name="ctype2" units="dimensionless">0</asymmetric_division_probability>
+                        <asymmetric_division_probability name="ctype3" units="dimensionless">1.0</asymmetric_division_probability>
+                    </standard_asymmetric_division>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_transition_rates units="1/min">
+                            <rate start_index="0" end_index="1" fixed_duration="false">0.001938</rate>
+                        </phase_transition_rates>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_transition_rates units="1/min">
+                            <rate start_index="0" end_index="1" fixed_duration="false">9000000000.0</rate>
+                            <rate start_index="1" end_index="2" fixed_duration="true">1.15741e-05</rate>
+                        </phase_transition_rates>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-02</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-05</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-4</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">7e-05</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0.0</calcified_fraction>
+                    <calcification_rate units="1/min">0.0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="ctype1">1.0</cell_adhesion_affinity>
+                        <cell_adhesion_affinity name="ctype2">1.0</cell_adhesion_affinity>
+                        <cell_adhesion_affinity name="ctype3">1.0</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1.0</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.7</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>true</enabled>
+                            <substrate>signal</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="signal">0.0</chemotactic_sensitivity>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="signal">
+                        <secretion_rate units="1/min">0.0</secretion_rate>
+                        <secretion_target units="substrate density">1.0</secretion_target>
+                        <uptake_rate units="1/min">0.0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0.0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0.0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0.0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0.0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="ctype1" units="1/min">0.0</phagocytosis_rate>
+                        <phagocytosis_rate name="ctype2" units="1/min">0.0</phagocytosis_rate>
+                        <phagocytosis_rate name="ctype3" units="1/min">0.0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="ctype1" units="1/min">0.0</attack_rate>
+                        <attack_rate name="ctype2" units="1/min">0.0</attack_rate>
+                        <attack_rate name="ctype3" units="1/min">0.0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1.0</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="ctype1" units="1/min">0.0</fusion_rate>
+                        <fusion_rate name="ctype2" units="1/min">0.0</fusion_rate>
+                        <fusion_rate name="ctype3" units="1/min">0.0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="ctype1" units="1/min">0.0</transformation_rate>
+                        <transformation_rate name="ctype2" units="1/min">0.0</transformation_rate>
+                        <transformation_rate name="ctype3" units="1/min">0.0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="true" units="dimensionless" description="">500</sample>
+                <dummy conserved="true" units="" description="">1000</dummy>
+                <myvec conserved="false" units="" description="">0.0, 0.1, 0.2</myvec>
+                <dummy2 conserved="true" units="" description="">2000</dummy2>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+          </initial_parameter_distributions>
+        </cell_definition>
+    </cell_definitions>
+
+    <initial_conditions>
+        <cell_positions type="csv" enabled="true">
+            <folder>./config</folder>
+            <filename>cycle_phase_cells.csv</filename>
+        </cell_positions>
+    </initial_conditions>
+
+    <user_parameters>
+        <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">0</number_of_cells>
+    </user_parameters>
+</PhysiCell_settings>

--- a/unit_tests/resume_sim/config/cycle_phase_cells.csv
+++ b/unit_tests/resume_sim/config/cycle_phase_cells.csv
@@ -1,0 +1,4 @@
+x,y,z,type,volume,cycle entry,custom:GFP,custom:sample
+-50.0,0.0,0.0,ctype1
+0.,0.,0.0,ctype2
+50.,0.,0.0,ctype3


### PR DESCRIPTION
Resume a simulation from a previous checkpoint:

* enhancement PR; only added code, didn't modify
* select a MultiCellDS file (output000*N.xml) as a starting point to continue a simulation
* does not handle intracellular model state
* does not currently recover "output*_graph.txt" data; rather, it relies on the next mechanics step to recreate that information
* if a model uses custom.cpp code that is not captured in the MultiCellDS data, it cannot be recovered
* community testing is desired

Refer to README in `root/unit_tests/resume_sim`

Big thank you to @rb-arroyo for being an early and ongoing beta tester and to @heberlr and @elmbeech for design discussions and insights.