### PR TITLE
Updating Intel Mac runners to MacOS 15

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -127,17 +127,17 @@ jobs:
           {short_name: "episode", project: "episode-sample", name: "PhysiCell Episode", binary: "project", extra_run: ""},
        ]
     
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
       run : |
-        if ! brew list gcc@13 &>/dev/null; then
-          brew install gcc@13
+        if ! brew list gcc@14 &>/dev/null; then
+          brew install gcc@14
         else
-          echo "gcc@13 is already installed."
+          echo "gcc@14 is already installed."
         fi
       
     - name: Build ${{ matrix.projects.name }} project
@@ -146,15 +146,15 @@ jobs:
         make ${{ matrix.projects.project }}
         make clean
         ${{ matrix.projects.extra_run }}
-        make PHYSICELL_CPP=g++-13 static
-        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos13
+        make PHYSICELL_CPP=g++-14 static
+        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos_intel
 
     - name: Caching produced project binary 
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos13
-        key: ${{ runner.os }}-macos13-${{ github.run_id }}
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_intel
+        key: ${{ runner.os }}-macos-intel-${{ github.run_id }}
     
     - name: Look at the generated binary
       run: |
@@ -184,10 +184,10 @@ jobs:
 
     - name: Install dependencies
       run : |
-        if ! brew list gcc@13 &>/dev/null; then
-          brew install gcc@13
+        if ! brew list gcc@14 &>/dev/null; then
+          brew install gcc@14
         else
-          echo "gcc@13 is already installed."
+          echo "gcc@14 is already installed."
         fi
       
     - name: Build ${{ matrix.projects.name }} project
@@ -196,15 +196,15 @@ jobs:
         make ${{ matrix.projects.project }}
         make clean
         ${{ matrix.projects.extra_run }}
-        make PHYSICELL_CPP=g++-13 static
-        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macosm1
+        make PHYSICELL_CPP=g++-14 static
+        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos_arm
    
     - name: Caching produced project binary 
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macosm1
-        key: ${{ runner.os }}-macosm1-${{ github.run_id }}
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_arm
+        key: ${{ runner.os }}-macos-arm-${{ github.run_id }}
       
     - name: Look at the generated binary
       run: |
@@ -227,7 +227,7 @@ jobs:
           {short_name: "episode", project: "episode-sample", name: "PhysiCell Episode", binary: "project", extra_run: ""},
         ]
         
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: [macos_step0a, macos_step0b]
 
     steps:
@@ -237,20 +237,19 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macosm1
-        key: ${{ runner.os }}-macosm1-${{ github.run_id }}
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_arm
+        key: ${{ runner.os }}-macos-arm-${{ github.run_id }}
     
     - name: Caching produced project binary 
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos13
-        key: ${{ runner.os }}-macos13-${{ github.run_id }}
+          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_intel
+        key: ${{ runner.os }}-macos-intel-${{ github.run_id }}
     
     - name: Creating universal binary
       run: | 
-        lipo -create -output ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos13 ${{ matrix.projects.binary }}_macosm1
-
+        lipo -create -output ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos_arm ${{ matrix.projects.binary }}_macos_intel
     - name: Checking universal binary
       run: |
         lipo -archs ${{ matrix.projects.binary }}

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -147,13 +147,13 @@ jobs:
         make clean
         ${{ matrix.projects.extra_run }}
         make PHYSICELL_CPP=g++-14 static
-        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos_intel
+        cp ${{ matrix.projects.binary }} ${{ matrix.projects.short_name }}_macos_intel
 
     - name: Caching produced project binary 
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_intel
+          ${{ github.workspace }}/${{ matrix.projects.short_name }}_macos_intel
         key: ${{ runner.os }}-macos-intel-${{ github.run_id }}
     
     - name: Look at the generated binary
@@ -197,13 +197,13 @@ jobs:
         make clean
         ${{ matrix.projects.extra_run }}
         make PHYSICELL_CPP=g++-14 static
-        cp ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos_arm
+        cp ${{ matrix.projects.binary }} ${{ matrix.projects.short_name }}_macos_arm
    
     - name: Caching produced project binary 
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_arm
+          ${{ github.workspace }}/${{ matrix.projects.short_name }}_macos_arm
         key: ${{ runner.os }}-macos-arm-${{ github.run_id }}
       
     - name: Look at the generated binary
@@ -237,19 +237,19 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_arm
+          ${{ github.workspace }}/${{ matrix.projects.short_name }}_macos_arm
         key: ${{ runner.os }}-macos-arm-${{ github.run_id }}
     
     - name: Caching produced project binary 
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ matrix.projects.binary }}_macos_intel
+          ${{ github.workspace }}/${{ matrix.projects.short_name }}_macos_intel
         key: ${{ runner.os }}-macos-intel-${{ github.run_id }}
     
     - name: Creating universal binary
       run: | 
-        lipo -create -output ${{ matrix.projects.binary }} ${{ matrix.projects.binary }}_macos_arm ${{ matrix.projects.binary }}_macos_intel
+        lipo -create -output ${{ matrix.projects.binary }} ${{ matrix.projects.short_name }}_macos_arm ${{ matrix.projects.short_name }}_macos_intel
     - name: Checking universal binary
       run: |
         lipo -archs ${{ matrix.projects.binary }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         os: [
           {name: "Ubuntu", os: "ubuntu-latest", shell: "bash", compiler: "g++"},
-          {name: "MacOS 13", os: "macos-13", shell: "bash", compiler: "g++-12"},
-          {name: "MacOS 14 (M1)", os: "macos-14", shell: "bash", compiler: "g++-13"},
+          {name: "MacOS 15", os: "macos-15-intel", shell: "bash", compiler: "g++-14"},
+          {name: "MacOS 14 (M1)", os: "macos-14", shell: "bash", compiler: "g++-14"},
           {name: "Windows", os: "windows-latest", shell: "msys2", compiler: "g++"},
         ]
         projects: [


### PR DESCRIPTION
Intel Mac runners using MacOS 13 are retired, the new available ones are using MacOS 15. 
This was causing the macos-13 workflows to fail. 
This also includes the #366 From @drbergman 