### PR TITLE
Update libroadrunner setup

### DIFF
--- a/addons/libRoadrunner/CMakeLists.txt
+++ b/addons/libRoadrunner/CMakeLists.txt
@@ -36,7 +36,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(roadrunner)
 
 target_include_directories(libRoadrunner
-                           PUBLIC ${roadrunner_SOURCE_DIR}/include/rr/C)
+                           PUBLIC ${roadrunner_SOURCE_DIR}/include/rr)
 target_link_directories(libRoadrunner PUBLIC ${roadrunner_SOURCE_DIR}/lib)
 target_link_libraries(libRoadrunner PUBLIC roadrunner_c_api)
 target_compile_definitions(libRoadrunner PUBLIC ADDON_ROADRUNNER)

--- a/beta/setup_libroadrunner.py
+++ b/beta/setup_libroadrunner.py
@@ -62,12 +62,11 @@ else:
         url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_win_x86_64.zip"
     elif os_type.lower().startswith("linux"):
         reminder_dynamic_link_path_linux()
-#        rr_file = "roadrunner_ubuntu_24.zip"
-#        url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_ubuntu_24.zip"
+        # the following "manylinux" seems to work on more flavors/releases of Linux than the roadrunner_ubuntu_24.zip which still exists on github.com/PhysiCell-Tools/intracellular_libs
         rr_file = "roadrunner_manylinux.zip"
         url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_manylinux.zip"
     else:
-        print("Your operating system seems to be unsupported. Please submit a ticket at https://sourceforge.net/p/physicell/tickets/ ")
+        print("Your operating system seems to be unsupported. Please create an issue on the PhysiCell GitHub repo or reach out on our Slack channel.")
         sys.exit(1)
 
     print("url=",url)
@@ -135,20 +134,8 @@ else:
     try:
         with zipfile.ZipFile(rr_file) as zf:
             zf.extractall('.')   # should create "roadrunner" directory
-        # rr_dir = rr_file[:-4]
-        # print(f'renaming dir: {rr_dir} to {new_dir_name}')
-        # os.rename(rr_dir, new_dir_name)
     except:
         print('error unzipping the file')
         exit(1)
 
     print('Done.\n')
-
-    # # LIBRR_DIR := /Users/heiland/libroadrunner/roadrunner-osx-10.9-cp36m
-    # print("Replace the following variables in your PhysiCell Makefile with these:\n")
-    # #print("LIBRR_DIR := /Users/heiland/libroadrunner/roadrunner-osx-10.9-cp36m")
-    # print("LIBRR_DIR := " + rrlib_dir)
-    # if os_type == 'Windows':
-    #     print("LIBRR_LIBS := " + rrlib_dir + "/bin\n")
-    # else:
-    #     print("LIBRR_LIBS := " + rrlib_dir + "/lib\n")

--- a/beta/setup_libroadrunner.py
+++ b/beta/setup_libroadrunner.py
@@ -138,4 +138,21 @@ else:
         print('error unzipping the file')
         exit(1)
 
-    print('Done.\n')
+
+    # Hack to maintain backwards compatibility. Originally our header path was .../include/rr/C, 
+    # but newer releases of the libroadrunner C API seems to have dropped the "/C" directory and put everything in "/rr"
+    dst =  "roadrunner/include/rr/C"
+    try:
+        os.remove(dst)
+    except FileNotFoundError:
+        print(f"File '{dst}' does not exist.")
+
+    try:
+        src =  "."
+        os.symlink(src, dst)
+        print(f"Symbolic link '{dst}' created, pointing to '{src}'")
+    except FileExistsError:
+        print(f"Symlink '{dst}' already exists")
+    except OSError as e:
+        print(f"Error creating symlink: {e}")
+        print('Done.\n')

--- a/beta/setup_libroadrunner.py
+++ b/beta/setup_libroadrunner.py
@@ -21,7 +21,7 @@ def reminder_dynamic_link_path_macos():
 def reminder_dynamic_link_path_linux():
     print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
     print("*    NOTE: if you have not yet done this, you need to specify where the shared libs can be found, e.g., via bash shell:")
-    print('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./addons/libRoadrunner/roadrunner/lib')
+    print('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./addons/libRoadrunner/roadrunner/lib64')
 
     print("\n*      To make this permanent, add this line to the bottom of the respective shell startup file, e.g., .bashrc, .bash_profile, or .zshenv in your home directory.")
     print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
@@ -62,8 +62,10 @@ else:
         url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_win_x86_64.zip"
     elif os_type.lower().startswith("linux"):
         reminder_dynamic_link_path_linux()
-        rr_file = "roadrunner_ubuntu_24.zip"
-        url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_ubuntu_24.zip"
+#        rr_file = "roadrunner_ubuntu_24.zip"
+#        url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_ubuntu_24.zip"
+        rr_file = "roadrunner_manylinux.zip"
+        url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_manylinux.zip"
     else:
         print("Your operating system seems to be unsupported. Please submit a ticket at https://sourceforge.net/p/physicell/tickets/ ")
         sys.exit(1)

--- a/beta/setup_libroadrunner.py
+++ b/beta/setup_libroadrunner.py
@@ -8,7 +8,6 @@ import platform
 import urllib.request
 import os
 import sys
-import tarfile
 import zipfile
 
 def reminder_dynamic_link_path_macos():
@@ -27,15 +26,12 @@ def reminder_dynamic_link_path_linux():
     print("\n*      To make this permanent, add this line to the bottom of the respective shell startup file, e.g., .bashrc, .bash_profile, or .zshenv in your home directory.")
     print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
 
-os_type = platform.system()
-
-# Old:
-# if os.path.exists(os.path.join(os.path.dirname(os.path.dirname(__file__)), "addons", "libRoadrunner", "roadrunner")):
+os_type = platform.system()  # can test that it downloads correct OS .zip by overriding this value
 
 # New: July 2023 - trying to be smarter about deciding whether to (re)download libRR
 #  NOTE: needs to be tested cross-platform!
-if os.path.exists(os.path.join(os.path.dirname(os.path.dirname(__file__)), "addons", "libRoadrunner", "roadrunner","include","rr","C","rrc_api.h")):
-    print('\nlibroadrunner already installed.\n')
+if os.path.exists(os.path.join(os.path.dirname(os.path.dirname(__file__)), "addons", "libRoadrunner", "roadrunner","include","rr","rrc_api.h")):
+    print('\nNote: libroadrunner is already installed so we will not re-install it. \nIf you want to force a re-install, delete the "roadrunner" directory in /addons/libRoadrunner then re-compile.\n')
 
     # regardless, let's remind the user about the env var requirement!
     if os_type.lower() == 'darwin':
@@ -55,38 +51,30 @@ else:
     if os_type.lower() == 'darwin':
         reminder_dynamic_link_path_macos()
         if "ARM64" in platform.uname().version:
-            # pass
-            # print('... for the arm64 processor.')
-            # url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/libs/macos12_arm64/libroadrunner_c_api.dylib"
-            rr_file = "roadrunner_macos_arm64.tar.gz"
-            url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_macos_arm64.tar.gz"
+            rr_file = "roadrunner_macos_arm64.zip"
+            url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_macos_arm64.zip"
             mac_silicon = True
         else:
-            rr_file = "roadrunner-osx-10.9-cp36m.tar.gz"
-            url = "https://sourceforge.net/projects/libroadrunner/files/libroadrunner-1.4.18/" + rr_file + "/download"
+            rr_file = "roadrunner_macos_x86_64.zip"
+            url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_macos_x86_64.zip"
     elif os_type.lower().startswith("win"):
-        rr_file = "roadrunner-win64-vs14-cp35m.zip"
-        url = "https://sourceforge.net/projects/libroadrunner/files/libroadrunner-1.4.18/" + rr_file + "/download"
+        rr_file = "roadrunner_win_x86_64.zip"
+        url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_win_x86_64.zip"
     elif os_type.lower().startswith("linux"):
         reminder_dynamic_link_path_linux()
-        rr_file = "cpplibroadrunner-1.3.0-linux_x86_64.tar.gz"
-        url = "https://sourceforge.net/projects/libroadrunner/files/libroadrunner-1.3/" + rr_file + "/download"
+        rr_file = "roadrunner_ubuntu_24.zip"
+        url = "https://github.com/PhysiCell-Tools/intracellular_libs/raw/main/ode/roadrunner_ubuntu_24.zip"
     else:
         print("Your operating system seems to be unsupported. Please submit a ticket at https://sourceforge.net/p/physicell/tickets/ ")
         sys.exit(1)
 
     print("url=",url)
-    if mac_silicon:
-        fname = url.split('/')[-1]
-    else:
-        fname = url.split('/')[-2]
+    fname = url.split('/')[-1]
     print("fname=",fname)
 
-    # home = os.path.expanduser("~")
     print('libRoadRunner will now be installed into this location:')
-    # dir_name = os.path.join(home, 'libroadrunner')
     dir_name = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'addons', 'libRoadrunner')
-    print(dir_name + '\n')
+    print(f'Will create {dir_name} if it does not exist.')
     # print('   - Press ENTER to confirm the location')
     # print('   - Press CTL-C to abort the installation')
     # print('   - Or specify a different location below\n')
@@ -121,17 +109,8 @@ else:
     my_file = os.path.join(dir_name, fname)
     print('my_file = ',my_file)
 
-    if os_type.lower().startswith("win"):
-        rrlib_dir = my_file[:-4]
-    else:  # darwin or linux
-        if mac_silicon:
-            # idx_end = my_file.rindex('/')
-            # rrlib_dir = my_file[:idx_end]
-            rrlib_dir = my_file[:-7]
-            # rrlib_dir = my_file
-        else:
-            rrlib_dir = my_file[:-7]
-    print('rrlib_dir = ',rrlib_dir)
+    # rrlib_dir = my_file[:-4]   # assume all are .zip
+    # print('rrlib_dir = ',rrlib_dir)
 
     def download_cb(blocknum, blocksize, totalsize):
         readsofar = blocknum * blocksize
@@ -148,36 +127,18 @@ else:
     urllib.request.urlretrieve(url, my_file, download_cb)
 
     new_dir_name = "roadrunner"
+    print(f"chdir to {dir_name}")
     os.chdir(dir_name)
     print('installing (uncompressing) the file...')
-    if os_type.lower().startswith("win"):
-        try:
-            with zipfile.ZipFile(rr_file) as zf:
-                zf.extractall('.')
-            os.rename("roadrunner-win64-vs14-cp35m", new_dir_name)
-        except:
-            print('error unzipping the file')
-            exit(1)
-    else:  # Darwin or Linux
-        try:
-            print("untarring ",rr_file)
-            tar = tarfile.open(rr_file)
-            tar.extractall()
-            tar.close()
-            if 'darwin' in os_type.lower():
-                if mac_silicon:
-                    os.rename("roadrunner_macos_arm64", new_dir_name)
-                else:
-                    os.rename("roadrunner-osx-10.9-cp36m", new_dir_name)
-            else:
-                os.rename("libroadrunner", new_dir_name)
-        except:
-            if mac_silicon:
-                print()
-                # pass
-            else:
-                print('error untarring the file')
-                exit(1)
+    try:
+        with zipfile.ZipFile(rr_file) as zf:
+            zf.extractall('.')   # should create "roadrunner" directory
+        # rr_dir = rr_file[:-4]
+        # print(f'renaming dir: {rr_dir} to {new_dir_name}')
+        # os.rename(rr_dir, new_dir_name)
+    except:
+        print('error unzipping the file')
+        exit(1)
 
     print('Done.\n')
 

--- a/beta/setup_libroadrunner.py
+++ b/beta/setup_libroadrunner.py
@@ -21,7 +21,7 @@ def reminder_dynamic_link_path_macos():
 def reminder_dynamic_link_path_linux():
     print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
     print("*    NOTE: if you have not yet done this, you need to specify where the shared libs can be found, e.g., via bash shell:")
-    print('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./addons/libRoadrunner/roadrunner/lib64')
+    print('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./addons/libRoadrunner/roadrunner/lib')
 
     print("\n*      To make this permanent, add this line to the bottom of the respective shell startup file, e.g., .bashrc, .bash_profile, or .zshenv in your home directory.")
     print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -34,7 +34,7 @@ else
 #		LIBRR_DIR := $(shell pwd)/intracellular_libs/roadrunner
 		LIBRR_DIR := ./addons/libRoadrunner/roadrunner
 		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr
-		LIBRR_LIBS := ${LIBRR_DIR}/lib
+		LIBRR_LIBS := ${LIBRR_DIR}/lib64
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		OSFLAG += -D OSX

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -17,12 +17,8 @@ OSFLAG 	:=
 ifeq ($(OS),Windows_NT)
 	OSFLAG += -D WIN32
 	OMP_LIB := 
-#	LIBRR_DIR := C:\Users\heiland\libroadrunner\roadrunner-win64-vs14-cp35m
-#	LIBRR_LIBS := C:\Users\heiland\libroadrunner\roadrunner-win64-vs14-cp35m/bin
-#	LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr/C
-#	CFLAGS := -march=$(ARCH) -fomit-frame-pointer -fopenmp -m64 -std=c++11 -D ADDON_ROADRUNNER 
 	LIBRR_DIR := .\addons\libRoadrunner\roadrunner
-	LIBRR_CFLAGS := -I${LIBRR_DIR}\include\rr\C
+	LIBRR_CFLAGS := -I${LIBRR_DIR}\include\rr
 	LIBRR_LIBS := ${LIBRR_DIR}\lib
 	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
 		OSFLAG += -D AMD64
@@ -37,13 +33,13 @@ else
 		OMP_LIB :=
 #		LIBRR_DIR := $(shell pwd)/intracellular_libs/roadrunner
 		LIBRR_DIR := ./addons/libRoadrunner/roadrunner
-		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr/C
+		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr
 		LIBRR_LIBS := ${LIBRR_DIR}/lib
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		OSFLAG += -D OSX
 		LIBRR_DIR := ./addons/libRoadrunner/roadrunner
-		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr/C
+		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr
 		LIBRR_LIBS := ${LIBRR_DIR}/lib
 	endif
 
@@ -52,7 +48,7 @@ else
 #	ifeq ($(UNAME_P),x86_64)
 #		OSFLAG += -D AMD64
 #		LIBRR_DIR := $(shell pwd)/intracellular_libs/roadrunner
-#		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr/C
+#		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr
 #		# CFLAGS := -march=$(ARCH) -fomit-frame-pointer -fopenmp -m64 -std=c++11 -D LIBROADRUNNER 
 #		CFLAGS := -march=$(ARCH) -fomit-frame-pointer -fopenmp -m64 -std=c++11 -D ADDON_ROADRUNNER 
 #	endif

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -18,7 +18,7 @@ ifeq ($(OS),Windows_NT)
 	OSFLAG += -D WIN32
 	OMP_LIB := 
 	LIBRR_DIR := .\addons\libRoadrunner\roadrunner
-	LIBRR_CFLAGS := -I${LIBRR_DIR}\include\rr
+	LIBRR_CFLAGS := -I${LIBRR_DIR}\include\rr\C
 	LIBRR_LIBS := ${LIBRR_DIR}\lib
 	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
 		OSFLAG += -D AMD64
@@ -33,31 +33,16 @@ else
 		OMP_LIB :=
 #		LIBRR_DIR := $(shell pwd)/intracellular_libs/roadrunner
 		LIBRR_DIR := ./addons/libRoadrunner/roadrunner
-		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr
-		LIBRR_LIBS := ${LIBRR_DIR}/lib64
+		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr/C
+		LIBRR_LIBS := ${LIBRR_DIR}/lib
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		OSFLAG += -D OSX
 		LIBRR_DIR := ./addons/libRoadrunner/roadrunner
-		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr
+		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr/C
 		LIBRR_LIBS := ${LIBRR_DIR}/lib
 	endif
 
-#	 Not sure if useful later or not.
-#	UNAME_P := $(shell uname -p)
-#	ifeq ($(UNAME_P),x86_64)
-#		OSFLAG += -D AMD64
-#		LIBRR_DIR := $(shell pwd)/intracellular_libs/roadrunner
-#		LIBRR_CFLAGS := -I${LIBRR_DIR}/include/rr
-#		# CFLAGS := -march=$(ARCH) -fomit-frame-pointer -fopenmp -m64 -std=c++11 -D LIBROADRUNNER 
-#		CFLAGS := -march=$(ARCH) -fomit-frame-pointer -fopenmp -m64 -std=c++11 -D ADDON_ROADRUNNER 
-#	endif
-#	ifneq ($(filter %86,$(UNAME_P)),)
-#		OSFLAG += -D IA32
-#	endif
-#	ifneq ($(filter arm%,$(UNAME_P)),)
-#		OSFLAG += -D ARM
-#	endif
 endif
 
 COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) 
@@ -95,6 +80,10 @@ all: libRoadrunner main.cpp $(ALL_OBJECTS)
 	$(COMPILE_COMMAND) $(OMP_LIB) -o $(PROGRAM_NAME) $(ALL_OBJECTS) main.cpp -L$(LIBRR_LIBS) -lroadrunner_c_api
 	@echo
 	@echo created $(PROGRAM_NAME)
+	@echo
+	@echo 'remember on Mac: export DYLD_LIBRARY_PATH=$$DYLD_LIBRARY_PATH:./addons/libRoadrunner/roadrunner/lib'
+	@echo 'remember on Linux: export LD_LIBRARY_PATH=$$LD_LIBRARY_PATH:./addons/libRoadrunner/roadrunner/lib'
+	@echo 'You can safely delete the downloaded .zip file in addons/libRoadrunner'
 	@echo
 
 name:


### PR DESCRIPTION
* cleanup and update the `beta/setup_libroadrunner.py` script
   * we now get more recent headers and libs (.zip bundles) from `https://github.com/PhysiCell-Tools/intracellular_libs/tree/main/ode` instead of very old ones from sourceforge
   * these are minimal versions of those provided at `https://github.com/sys-bio/roadrunner/releases` (but probably not the very latest release)
 * cleanup and fix the Makefile for the `ode-energy-sample` project to use the new directory structure in these new .zip bundles
 * tested on Windows, Mac (both Silicon and Intel), and Linux (Ubuntu 24.04)