### PR TITLE
Add trim_cr utility function and apply it to CSV parsing in multiple files

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -47,6 +47,7 @@
 */
 
 #include "BioFVM_microenvironment.h"
+#include "BioFVM_utilities.h"
 #include "BioFVM_solvers.h"
 #include "BioFVM_vector.h"
 #include <cmath>
@@ -1467,6 +1468,7 @@ void load_initial_conditions_from_csv(std::string filename)
 	// determine if header row exists 
 	std::string line; 
 	std::getline( file , line );
+	trim_cr(line);
 	char c = line.c_str()[0];
 	std::vector<int> substrate_indices;
 	bool header_provided = false;
@@ -1515,6 +1517,7 @@ void load_initial_conditions_from_csv(std::string filename)
 		file.close();
 		std::ifstream file(filename, std::ios::in);
 		std::getline(file, line);
+		trim_cr(line);
 	}
 
 	std::cout << "Loading substrate initial conditions from CSV file " << filename << " ... " << std::endl;
@@ -1522,6 +1525,7 @@ void load_initial_conditions_from_csv(std::string filename)
 	
 	while (std::getline(file, line))
 	{
+		trim_cr(line);
 		get_row_from_substrate_initial_condition_csv(voxel_set, line, substrate_indices, header_provided);
 	}
 	

--- a/BioFVM/BioFVM_utilities.h
+++ b/BioFVM/BioFVM_utilities.h
@@ -78,9 +78,12 @@ void seed_random( void );
 double uniform_random( void );
 
 double compute_mean( std::vector<double>& values );
-double compute_variance( std::vector<double>& values, double mean ); 
-double compute_variance( std::vector<double>& values ); 
-	
+double compute_variance( std::vector<double>& values, double mean );
+double compute_variance( std::vector<double>& values );
+
+inline void trim_cr( std::string& line )
+{ if (!line.empty() && line.back() == '\r') { line.pop_back(); } }
+
 };
  
 #endif 

--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -1535,8 +1535,9 @@ void parse_csv_rules_v0( std::string filename )
 
 	while( fs.eof() == false )
 	{
-		std::string line; 	
-		std::getline( fs , line, '\n'); 
+		std::string line;
+		std::getline( fs , line, '\n');
+		trim_cr(line);
 		if( line.size() > 0 )
 		{ parse_csv_rule_v0(line); }
 	}
@@ -1671,8 +1672,9 @@ void parse_csv_rules_v1( std::string filename )
 
 	while( fs.eof() == false )
 	{
-		std::string line; 	
-		std::getline( fs , line, '\n'); 
+		std::string line;
+		std::getline( fs , line, '\n');
+		trim_cr(line);
 		if( line.size() > 0 )
 		{ parse_csv_rule_v1(line); }
 	}
@@ -1804,8 +1806,9 @@ void parse_csv_rules_v3( std::string filename )
 
 	while( fs.eof() == false )
 	{
-		std::string line; 	
-		std::getline( fs , line, '\n'); 
+		std::string line;
+		std::getline( fs , line, '\n');
+		trim_cr(line);
 		if( line.size() > 0 )
 		{ parse_csv_rule_v3(line); }
 	}

--- a/modules/PhysiCell_geometry.cpp
+++ b/modules/PhysiCell_geometry.cpp
@@ -308,6 +308,7 @@ void load_cells_csv_v1( std::string filename )
 	std::string line;
 	while (std::getline(file, line))
 	{
+		trim_cr(line);
 		std::vector<double> data;
 		csv_to_vector( line.c_str() , data ); 
 
@@ -840,6 +841,7 @@ void load_cells_csv_v2( std::string filename )
 
 	std::string line; 
 	std::getline( file , line ); 
+	trim_cr(line);
 
 	// tokenize the labels 
 
@@ -848,7 +850,10 @@ void load_cells_csv_v2( std::string filename )
 	// process all remaining lines 
 
 	while (std::getline(file, line))
-	{ process_csv_v2_line(line,labels); }	
+	{
+		trim_cr(line);
+		process_csv_v2_line(line,labels);
+	}
 
 	// close the file 
 
@@ -871,6 +876,7 @@ void load_cells_csv( std::string filename )
 	// determine version 
 	std::string line; 
 	std::getline( file , line );
+	trim_cr(line);
 	char c = line.c_str()[0]; 
 
 	file.close(); 


### PR DESCRIPTION
## Fix CRLF line endings breaking CSV parsers on Unix/macOS

### Problem

On Unix and macOS, `std::getline` does not strip the carriage return (`\r`) from lines with Windows-style CRLF (`\r\n`) endings. This is a common real-world scenario: Excel exports CSV with CRLF line endings even on macOS, and files authored on Windows carry the same encoding. Every line retains a trailing `\r` after `getline`, causing string comparisons to silently fail — e.g. `"default\r" != "default"`, `"oxygen\r" != "oxygen"`. This affects cell loading, rules parsing, and substrate initial conditions.

Closes / related: MathCancer/PhysiCell#272

Prior to this fix, loading a CRLF cell CSV would produce console output like:

```
Loading cells from detailed (v2) CSV file ./config/cells.csv ... 
 not found!ll_Definition for default
Warning! CSV file requests creating cell type default
        at 0 0 0 but I don't recognize that type. Skipping cell!

Creating default (type=0) at 10 0 0 
```

The first cell is skipped because `"default\r"` does not match `"default"`. The last line of the file succeeds because it has no trailing `\r` (no CRLF after the final newline). The garbled ` not found!ll_Definition for default` line is caused by the `\r` returning the cursor to column 0 mid-output and overwriting part of the previous message.

### What changed

Added `trim_cr(std::string& line)` as a shared `inline` utility in `BioFVM/BioFVM_utilities.h`. It strips a trailing `\r` if present and is a no-op on LF-only files. It is called immediately after every `std::getline` that reads from a file in the affected parsers.

**Files changed**

| File | Change |
|------|--------|
| `BioFVM/BioFVM_utilities.h` | Added `inline void trim_cr(std::string& line)` |
| `BioFVM/BioFVM_microenvironment.cpp` | Added `#include "BioFVM_utilities.h"`; call `trim_cr` after each file `getline` in `load_initial_conditions_from_csv` |
| `modules/PhysiCell_geometry.cpp` | Call `trim_cr` after each file `getline` in `load_cells_csv`, `load_cells_csv_v1`, `load_cells_csv_v2` |
| `core/PhysiCell_rules.cpp` | Call `trim_cr` after each file `getline` in `parse_csv_rules_v0`, `parse_csv_rules_v1`, `parse_csv_rules_v3` |

### Testing

Create a minimal cell CSV:

```
x,y,z,type
0,0,0,default
10,0,0,default
```

**To save as CRLF in VS Code:** Click the `LF` or `CRLF` indicator in the bottom-right status bar → select `CRLF` → save.

**To save as LF in VS Code:** Same control → select `LF` → save.

Confirm cells load correctly with both versions. Prior to this fix, the CRLF version would fail to match cell type names and skip all cells or exit with an error.