### PR TITLE
Generate header dependencies so header edits trigger a rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ Studio.zip
 /worm
 /*.exe
 
+# generated header-dependency files (-MMD)
+*.d
+
 # boolean intracellular project executables
 /invasion_model
 /PhysiBoSS_Cell_Lines

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -435,6 +440,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -560,3 +566,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -35,7 +35,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -435,6 +440,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -560,3 +566,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/asymmetric_division/Makefile
+++ b/sample_projects/asymmetric_division/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -183,6 +188,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -313,3 +319,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -41,7 +41,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -184,6 +189,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/custom_division/Makefile
+++ b/sample_projects/custom_division/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/episode/Makefile
+++ b/sample_projects/episode/Makefile
@@ -51,7 +51,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -198,6 +203,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -323,3 +329,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/immune_function/Makefile
+++ b/sample_projects/immune_function/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -321,3 +327,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/mechano/Makefile
+++ b/sample_projects/mechano/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -212,6 +217,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -337,3 +343,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -313,3 +319,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -321,3 +327,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -321,3 +327,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -75,7 +75,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -245,6 +250,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -357,3 +363,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -73,7 +73,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -242,6 +247,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -353,3 +359,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -73,7 +73,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -242,6 +247,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -367,3 +373,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -75,7 +75,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -246,6 +251,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -358,3 +364,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/fba/cancer_metabolism/Makefile
+++ b/sample_projects_intracellular/fba/cancer_metabolism/Makefile
@@ -45,7 +45,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPS_CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPS_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -216,6 +221,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -246,3 +252,7 @@ unzip:
 untar:
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
+++ b/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
@@ -97,7 +97,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBFBA_CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBFBA_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -263,6 +268,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -296,3 +302,7 @@ unzip:
 untar:
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -64,7 +64,12 @@ else
 #	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -216,6 +221,7 @@ librr_intracellular.o: ./addons/libRoadrunner/src/librr_intracellular.cpp ./addo
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -273,3 +279,7 @@ unzip:
 untar: 
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/tests/timing/Makefile
+++ b/tests/timing/Makefile
@@ -16,7 +16,12 @@ ARCH := native # best auto-tuning
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 #CFLAGS := -g -fopenmp -std=c++11
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 DIR := ../..
 BioFVM_OBJECTS := $(DIR)/BioFVM_vector.o $(DIR)/BioFVM_mesh.o $(DIR)/BioFVM_microenvironment.o $(DIR)/BioFVM_solvers.o $(DIR)/BioFVM_matlab.o \
@@ -42,4 +47,9 @@ all: main.cpp $(ALL_OBJECTS)
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -15,7 +15,12 @@ ARCH := native # best auto-tuning
 # CFLAGS := -march=$(ARCH) -Ofast -s -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 DIR := ../..
 BioFVM_OBJECTS := $(DIR)/BioFVM_vector.o $(DIR)/BioFVM_mesh.o $(DIR)/BioFVM_microenvironment.o $(DIR)/BioFVM_solvers.o $(DIR)/BioFVM_matlab.o \
@@ -44,4 +49,9 @@ all: main.cpp $(ALL_OBJECTS)
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/cell_definition/Makefile
+++ b/unit_tests/cell_definition/Makefile
@@ -11,7 +11,12 @@ ARCH := native # best auto-tuning
 # CFLAGS := -march=$(ARCH) -Ofast -s -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11 -U LIBROADRUNNER 
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 ODIR := ../..
 
@@ -40,3 +45,7 @@ test_cell_def1:
 	$(COMPILE_COMMAND) -o test_cell_def1 $(ALL_OBJECTS) test_cell_def1.cpp 
 test_cell_def2: 
 	$(COMPILE_COMMAND) -o test_cell_def2 $(ALL_OBJECTS) test_cell_def2.cpp 
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -310,3 +316,7 @@ sci_package:
 	@echo "Project saved in $(PROJ)_packaged_$$(date +%b_%d_%Y_%H%M).zip."
 	@echo "It is fully self-contained and can be distributed as a separate GitHub repository."
 	@echo " "
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -184,6 +189,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -307,3 +313,7 @@ sci_package:
 	@echo "Project saved in $(PROJ)_packaged_$$(date +%b_%d_%Y_%H%M).zip."
 	@echo "It is fully self-contained and can be distributed as a separate GitHub repository."
 	@echo " "
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/substrate_internalization/Makefile-unit-test-conservation
+++ b/unit_tests/substrate_internalization/Makefile-unit-test-conservation
@@ -32,7 +32,12 @@ ARCH := native # best auto-tuning
 # CFLAGS := -march=$(ARCH) -Ofast -s -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -151,6 +156,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -182,3 +188,7 @@ unzip:
 untar: 
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)


### PR DESCRIPTION
## The problem

Make rebuilds a target only when a listed prereq is newer, but the headers are not explicitly in the prereqs. Thus, they are invisible for rebuild purposes. This means that a change to the header does not get caught by `make` to recompile.

## The change

`-MMD` makes the compiler write a `.d` file beside each `.o` listing the headers that object actually included. `-MP` adds a dummy target for each of those headers so that deleting or renaming one does not break the build with "No rule to make target". The `.d` files are then read back in as prerequisites. Nothing is hand-maintained.

Three lines per Makefile, applied to all 30:

- `DEPFLAGS := -MMD -MP`, appended to `COMPILE_COMMAND`. Not to `LINK_COMMAND`, which does not compile.
- `rm -f *.d` in `clean`. `unit_tests/cell_definition/Makefile` has no `clean` target, so it gets the flags and the include and nothing else.
- `-include $(ALL_OBJECTS:.o=.d)` at the very end of the file.

That last point is load-bearing and I left a comment saying so in each file. Each `.d` declares rules for its own `.o`, so including them any earlier in the file makes the first of those the default goal — `make` with no arguments would build `BioFVM_vector.o` and stop instead of building the project.

`*.d` is gitignored.

## Verification

Built four projects covering the shapes that differ — a plain one, one with an addon, and the two `COMPILE_COMMAND` variants — then touched `core/PhysiCell_cell.h` and asked make what it would do:

| project | objects | `.d` written | rebuilt after touching the header |
|---|---|---|---|
| `template` | 28 | 29 | 14 |
| `interaction-sample` | 28 | 29 | 14 |
| `physimess-sample` | 32 | 33 | 16 |
| `worm-sample` | 28 | 29 | 11 |

The counts differ per project because only the objects that actually include that header rebuild, which is the point. The control is the interesting one: with the current Makefiles the same touch rebuilds **zero** objects and goes straight to relinking.

## Scope

Deliberately mechanical and limited to the build system. No source file is touched. The intracellular projects that link prebuilt libraries get `.d` files only for the objects these Makefiles compile, which is strictly better than none.
