### PR TITLE
Fix uninitialized loop counter in intialize_hypothesis_rulesets

### DIFF
--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -885,7 +885,7 @@ void intialize_hypothesis_rulesets( void )
 {
 	hypothesis_rulesets.clear(); // empty(); 
 
-	for( int n; n < cell_definitions_by_index.size() ; n++ )
+	for( int n=0; n < cell_definitions_by_index.size() ; n++ )
 	{
 		Cell_Definition* pCD = cell_definitions_by_index[n]; 
 		add_hypothesis_ruleset(pCD); 


### PR DESCRIPTION
In `intialize_hypothesis_rulesets` (`core/PhysiCell_rules.cpp`), the loop counter is declared without an initializer:

```cpp
for( int n; n < cell_definitions_by_index.size() ; n++ )
```

this fixes that