### PR TITLE
Compare neighbor type against diff_type in the interactions sample

### DIFF
--- a/sample_projects/interactions/custom_modules/custom.cpp
+++ b/sample_projects/interactions/custom_modules/custom.cpp
@@ -680,7 +680,7 @@ void stem_cell_phenotype( Cell* pCell, Phenotype& phenotype, double dt )
 		{ 
 			if( pC->type == stem_type )
 			{ num_stem++; }
-			if( pC->type == num_differentiated )
+			if( pC->type == diff_type )
 			{ num_differentiated++; }
 			if( pC->type == bacteria_type )
 			{ num_bacteria++; }


### PR DESCRIPTION
An obvious typo in the interactions sample project. Fixing this likely changes simulation output and so we would need to fix the test artifacts.